### PR TITLE
Ignore configurations, code formatting, refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 globalnl-database-export.js
 /functions/*service-account.json
 .vscode
+.firebase

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 globalnl-database-export.js
 /functions/*service-account.json
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.log
 .DS_Store
 globalnl-database-export.js
+/functions/*service-account.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.linting.enabled": false
-}

--- a/functions/copyFirestoreDB.js
+++ b/functions/copyFirestoreDB.js
@@ -1,4 +1,4 @@
-const firebase = require('firebase-admin');
+const firebase = require("firebase-admin");
 
 var serviceAccountSource = require("./globalnl-database-service-account.json"); // source DB key
 var serviceAccountDestination = require("./globalnl-members-service-account.json"); // destiny DB key
@@ -7,9 +7,12 @@ const sourceAdmin = firebase.initializeApp({
   credential: firebase.credential.cert(serviceAccountSource)
 });
 
-const destinationAdmin = firebase.initializeApp({
-  credential: firebase.credential.cert(serviceAccountDestination)
-}, "destination");
+const destinationAdmin = firebase.initializeApp(
+  {
+    credential: firebase.credential.cert(serviceAccountDestination)
+  },
+  "destination"
+);
 
 /* this schema is how your DB is organized in a tree structure. You don't have to care about the Documents
   but you do need to inform the name of your collections and any subcollections, in this
@@ -19,12 +22,12 @@ const destinationAdmin = firebase.initializeApp({
 */
 const schema = {
   //members: {
- //   current_address: {},
+  //   current_address: {},
   //  hometown_address: {}
- //   },
+  //   },
   moderators: {},
   private_data: {
-	interests: {}
+    interests: {}
   }
 };
 
@@ -32,29 +35,38 @@ var source = sourceAdmin.firestore();
 var destination = destinationAdmin.firestore();
 
 const copy = (sourceDBrep, destinationDBref, schema) => {
-  return Promise.all(Object.keys(schema).map((collection) => {
-    return sourceDBrep.collection(collection).get()
-      .then((data) => {
-        let promises = [];
-        data.forEach((doc) => {
-          const data = doc.data();
-		  //if(doc.id.length > 25){
-			  //data.copied_account = false;
-		  //}
-          promises.push(
-            destinationDBref.collection(collection).doc(doc.id).set(data).then((data) => {
-              return copy(sourceDBrep.collection(collection).doc(doc.id),
-              destinationDBref.collection(collection).doc(doc.id),
-              schema[collection])
-            })
-          ); 
-        })
-      return Promise.all(promises);
+  return Promise.all(
+    Object.keys(schema).map(collection => {
+      return sourceDBrep
+        .collection(collection)
+        .get()
+        .then(data => {
+          let promises = [];
+          data.forEach(doc => {
+            const data = doc.data();
+            //if(doc.id.length > 25){
+            //data.copied_account = false;
+            //}
+            promises.push(
+              destinationDBref
+                .collection(collection)
+                .doc(doc.id)
+                .set(data)
+                .then(data => {
+                  return copy(
+                    sourceDBrep.collection(collection).doc(doc.id),
+                    destinationDBref.collection(collection).doc(doc.id),
+                    schema[collection]
+                  );
+                })
+            );
+          });
+          return Promise.all(promises);
+        });
     })
-  }));
+  );
 };
 
 copy(source, destination, schema).then(() => {
-  console.log('copied');
+  console.log("copied");
 });
-

--- a/functions/index.js
+++ b/functions/index.js
@@ -13,29 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
+"use strict";
 
-const functions = require('firebase-functions');
-const cookieParser = require('cookie-parser');
-const crypto = require('crypto');
+const functions = require("firebase-functions");
+const cookieParser = require("cookie-parser");
+const crypto = require("crypto");
 
 // Firebase Setup
-const admin = require('firebase-admin');
+const admin = require("firebase-admin");
 
-var serviceAccount = require('./globalnl-members-service-account.json');
+var serviceAccount = require("./globalnl-members-service-account.json");
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),
-  databaseURL: `https://${process.env.GCLOUD_PROJECT}.firebaseio.com`,
+  databaseURL: `https://${process.env.GCLOUD_PROJECT}.firebaseio.com`
 });
 var db = admin.firestore();
-const settings = {timestampsInSnapshots: true};
+const settings = { timestampsInSnapshots: true };
 db.settings(settings);
 
-const OAUTH_SCOPES = ['r_basicprofile', 'r_emailaddress'];
+const OAUTH_SCOPES = ["r_basicprofile", "r_emailaddress"];
 
 var member = {};
 var private_data = {};
-
 
 /**
  * Creates a configured LinkedIn API Client instance.
@@ -43,13 +42,13 @@ var private_data = {};
 function linkedInClient() {
   // LinkedIn OAuth 2 setup
   // TODO: Configure the `linkedin.client_id` and `linkedin.client_secret` Google Cloud environment variables.
-  return require('node-linkedin')(
-      functions.config().linkedin.client_id,
-      functions.config().linkedin.client_secret,
-	  `https://members.globalnl.com/login.html`);
-	  //`https://globalnl-members.firebaseapp.com/login.html`);
-	  //`https://memberstest.globalnl.com/login.html`);
-
+  return require("node-linkedin")(
+    functions.config().linkedin.client_id,
+    functions.config().linkedin.client_secret,
+    `https://members.globalnl.com/login.html`
+  );
+  //`https://globalnl-members.firebaseapp.com/login.html`);
+  //`https://memberstest.globalnl.com/login.html`);
 }
 
 /**
@@ -60,13 +59,13 @@ exports.redirect = functions.https.onRequest((req, res) => {
   const Linkedin = linkedInClient();
 
   cookieParser()(req, res, () => {
-    const state = req.cookies.state || crypto.randomBytes(20).toString('hex');
+    const state = req.cookies.state || crypto.randomBytes(20).toString("hex");
     //console.log('Setting verification state:', state);
-	//res.setHeader('Cache-Control', 'private');
-    res.cookie('state', state.toString(), {
+    //res.setHeader('Cache-Control', 'private');
+    res.cookie("state", state.toString(), {
       maxAge: 3600000,
       secure: true,
-      httpOnly: true,
+      httpOnly: true
     });
     Linkedin.auth.authorize(res, OAUTH_SCOPES, state.toString());
   });
@@ -79,68 +78,84 @@ exports.redirect = functions.https.onRequest((req, res) => {
  * 'callback' query parameter.
  */
 exports.token = functions.https.onRequest((req, res) => {
-	const Linkedin = linkedInClient();
+  const Linkedin = linkedInClient();
   //res.setHeader('Cache-Control', 'private');
-  
+
   try {
     return cookieParser()(req, res, () => {
       if (!req.cookies.state) {
-        throw new Error('State cookie not set or expired. Maybe you took too long to authorize. Please try again.');
+        throw new Error(
+          "State cookie not set or expired. Maybe you took too long to authorize. Please try again."
+        );
       }
       //console.log('Received verification state:', req.cookies.state);
       Linkedin.auth.authorize(OAUTH_SCOPES, req.cookies.state); // Makes sure the state parameter is set
       //console.log('Received auth code:', req.query.code);
       //console.log('Received state:', req.query.state);
-      Linkedin.auth.getAccessToken(res, req.query.code, req.query.state, (error, results) => {
-        if (error) {
-          throw error;
-        }
-        //console.log('Received Access Token:', results.access_token);
-        const linkedin = Linkedin.init(results.access_token);
-        linkedin.people.me((error, userResults) => {
+      Linkedin.auth.getAccessToken(
+        res,
+        req.query.code,
+        req.query.state,
+        (error, results) => {
           if (error) {
             throw error;
           }
-          //console.log('Auth code exchange result received:', userResults);
+          //console.log('Received Access Token:', results.access_token);
+          const linkedin = Linkedin.init(results.access_token);
+          linkedin.people.me((error, userResults) => {
+            if (error) {
+              throw error;
+            }
+            //console.log('Auth code exchange result received:', userResults);
 
-          // We have a LinkedIn access token and the user identity now.
-          //results.access_token;
-		  // The UID we'll assign to the user is 1In_ plus the internal LinkedIn user reference which is unique for our API key (one)
-		  // userResults.id
-		  
-		  console.log(userResults);
-		  		  
-		  member = {
-			first_name: (userResults.firstName.charAt(0).toUpperCase() + userResults.firstName.substr(1).toLowerCase()) || "",
-			last_name: (userResults.lastName.charAt(0).toUpperCase() + userResults.lastName.substr(1).toLowerCase()) || "",
-			display_name: userResults.formattedName || "",
-			headline: userResults.headline || "",
-			industry: userResults.industry || "",
-			linkedin_profile: userResults.publicProfileUrl || "",
-			photoURL: userResults.pictureUrl || "",
-			current_address: {LinkedInLocation: userResults.location.name || ""},
-			copied_account: false
-		  }
-		  //console.log(member);
-          // Create a Firebase account and get the Custom Auth Token.
-          return createFirebaseAccount('00LI_'+userResults.id, userResults.formattedName, userResults.pictureUrl, userResults.emailAddress).then(
-            (firebaseToken) => {
+            // We have a LinkedIn access token and the user identity now.
+            //results.access_token;
+            // The UID we'll assign to the user is 1In_ plus the internal LinkedIn user reference which is unique for our API key (one)
+            // userResults.id
+
+            console.log(userResults);
+
+            member = {
+              first_name:
+                userResults.firstName.charAt(0).toUpperCase() +
+                  userResults.firstName.substr(1).toLowerCase() || "",
+              last_name:
+                userResults.lastName.charAt(0).toUpperCase() +
+                  userResults.lastName.substr(1).toLowerCase() || "",
+              display_name: userResults.formattedName || "",
+              headline: userResults.headline || "",
+              industry: userResults.industry || "",
+              linkedin_profile: userResults.publicProfileUrl || "",
+              photoURL: userResults.pictureUrl || "",
+              current_address: {
+                LinkedInLocation: userResults.location.name || ""
+              },
+              copied_account: false
+            };
+            //console.log(member);
+            // Create a Firebase account and get the Custom Auth Token.
+            return createFirebaseAccount(
+              "00LI_" + userResults.id,
+              userResults.formattedName,
+              userResults.pictureUrl,
+              userResults.emailAddress
+            ).then(firebaseToken => {
               // Serve an HTML page that signs the user in and updates the user profile.
               return res.jsonp({
                 token: firebaseToken
               });
             });
-        });
-      });
+          });
+        }
+      );
     });
   } catch (error) {
-	  console.log('Error in cookie loading etc',error.toString());
+    console.log("Error in cookie loading etc", error.toString());
     return res.jsonp({
-      error: error.toString,
+      error: error.toString
     });
   }
 });
-
 
 /**
  * Creates a Firebase account with the given user profile and returns a custom auth token allowing
@@ -149,107 +164,135 @@ exports.token = functions.https.onRequest((req, res) => {
  *
  * @returns {Promise<string>} The Firebase custom auth token in a promise.
  */
-function createFirebaseAccount(uid, displayName, photoURL, email){
-
+function createFirebaseAccount(uid, displayName, photoURL, email) {
   // Save the access token to the Firebase Realtime Database.
   // Taking out now, if add back replace in Promises at end
   //const databaseTask = admin.database().ref(`/linkedInAccessToken/${uid}`).set(accessToken);
-  
 
   // Create or update the user account.
-const userTokenTask = admin.auth().updateUser(uid, {
-    displayName: displayName,
-    photoURL: photoURL,
-    email: email,
-    emailVerified: true
-  }).catch((error) => {
-    // If user does not exists we create it.
-    if (error.code === 'auth/user-not-found') {
-		console.log("Attempting to create a new account for: ", email);
-		//var uidOld;
-		// Create user account
-		const createUserTask = admin.auth().createUser({
-					uid: uid,
-					displayName: displayName,
-					photoURL: photoURL,
-					email: email,
-					emailVerified: true
-				})
-		  .catch(function(error) {
-					console.log("Error in createUserTask: ", error);
-			});	  
-	  
-		// See if user by same email exists in database. If so
-		// a) Save their interests/comments from retrieved private_data record
-		// b) Search for members record and save addresses
-		// c) Set flags on old members record 
-		const searchExistingUserTask = db.collection('private_data').where("email", "==", email).get()
-			.then((querySnapshot) => {
-				if(querySnapshot.docs.length > 0){
-					console.log("Found existing user for ", email, " ==> ", querySnapshot.docs[0].id);
-					member.uid_old = querySnapshot.docs[0].id;
-					if(querySnapshot.docs[0].data().interests != undefined) private_data.interests = querySnapshot.docs[0].data().interests;
-					if(querySnapshot.docs[0].data().comments != undefined) private_data.comments = querySnapshot.docs[0].data().comments;	
-					return db.collection('members').doc(querySnapshot.docs[0].id).get();
-				}
-				console.log("Unable to find existing user for ", email);
-				return false
-			})
-			.then((doc) => {
-				if(doc && doc.exists){
-					console.log("Found existing member record for ", email);
-					if(doc.data().current_address != undefined) member.current_address = doc.data().current_address;
-					if(doc.data().hometown_address != undefined) member.hometown_address = doc.data().hometown_address;
-					if(doc.data().privacy != undefined) member.privacy = doc.data().privacy;
-					member.date_updated = "-1"; //Set to -1 to trigger profile form update	
-					return db.collection('members').doc(doc.id).set({
-						copied_account: true,
-						uid_new: uid
-						},
-						{merge: true});
-				}
-				console.log("Didn't find existing member record for ", email);
-				return true
-			})
-			.catch(function(error) {
-					console.log("Error in searchExistingUserTask: ", error);
-			});
-		return Promise.all([createUserTask, searchExistingUserTask]).then(() => {
-			return false;
-		});
-    } // END IF
-    throw error;
-  })// END Catch
-  .then(() => {
-		const token = admin.auth().createCustomToken(uid);
-		
-		console.log("About to write member database record: ", uid);
-		
-		private_data.email = email || "";
-		
-		console.log(private_data);
-		console.log(member);
-		
-		const privateDatabaseTask = db.collection('private_data').doc(uid).set(
-		private_data,
-		{merge: true}
-		)
-		.catch(function(error){
-		console.log(error);
-		console.log("Error writing private database properties for ", uid);
-		});
-		const memberDatabaseTask = db.collection('members').doc(uid).set(
-		member,
-		{merge: true}
-		)
-		.catch(function(error){
-		console.log(error);
-		console.log("Error writing public database properties for ", uid);
-		});
-		return Promise.all([token, memberDatabaseTask, privateDatabaseTask]).then(() => {
-			// Create a Firebase custom auth token.
-			return token;
-		}); 
-  })
-  return userTokenTask //holds value of token 
+  const userTokenTask = admin
+    .auth()
+    .updateUser(uid, {
+      displayName: displayName,
+      photoURL: photoURL,
+      email: email,
+      emailVerified: true
+    })
+    .catch(error => {
+      // If user does not exists we create it.
+      if (error.code === "auth/user-not-found") {
+        console.log("Attempting to create a new account for: ", email);
+        //var uidOld;
+        // Create user account
+        const createUserTask = admin
+          .auth()
+          .createUser({
+            uid: uid,
+            displayName: displayName,
+            photoURL: photoURL,
+            email: email,
+            emailVerified: true
+          })
+          .catch(function(error) {
+            console.log("Error in createUserTask: ", error);
+          });
+
+        // See if user by same email exists in database. If so
+        // a) Save their interests/comments from retrieved private_data record
+        // b) Search for members record and save addresses
+        // c) Set flags on old members record
+        const searchExistingUserTask = db
+          .collection("private_data")
+          .where("email", "==", email)
+          .get()
+          .then(querySnapshot => {
+            if (querySnapshot.docs.length > 0) {
+              console.log(
+                "Found existing user for ",
+                email,
+                " ==> ",
+                querySnapshot.docs[0].id
+              );
+              member.uid_old = querySnapshot.docs[0].id;
+              if (querySnapshot.docs[0].data().interests != undefined)
+                private_data.interests = querySnapshot.docs[0].data().interests;
+              if (querySnapshot.docs[0].data().comments != undefined)
+                private_data.comments = querySnapshot.docs[0].data().comments;
+              return db
+                .collection("members")
+                .doc(querySnapshot.docs[0].id)
+                .get();
+            }
+            console.log("Unable to find existing user for ", email);
+            return false;
+          })
+          .then(doc => {
+            if (doc && doc.exists) {
+              console.log("Found existing member record for ", email);
+              if (doc.data().current_address != undefined)
+                member.current_address = doc.data().current_address;
+              if (doc.data().hometown_address != undefined)
+                member.hometown_address = doc.data().hometown_address;
+              if (doc.data().privacy != undefined)
+                member.privacy = doc.data().privacy;
+              member.date_updated = "-1"; //Set to -1 to trigger profile form update
+              return db
+                .collection("members")
+                .doc(doc.id)
+                .set(
+                  {
+                    copied_account: true,
+                    uid_new: uid
+                  },
+                  { merge: true }
+                );
+            }
+            console.log("Didn't find existing member record for ", email);
+            return true;
+          })
+          .catch(function(error) {
+            console.log("Error in searchExistingUserTask: ", error);
+          });
+        return Promise.all([createUserTask, searchExistingUserTask]).then(
+          () => {
+            return false;
+          }
+        );
+      } // END IF
+      throw error;
+    }) // END Catch
+    .then(() => {
+      const token = admin.auth().createCustomToken(uid);
+
+      console.log("About to write member database record: ", uid);
+
+      private_data.email = email || "";
+
+      console.log(private_data);
+      console.log(member);
+
+      const privateDatabaseTask = db
+        .collection("private_data")
+        .doc(uid)
+        .set(private_data, { merge: true })
+        .catch(function(error) {
+          console.log(error);
+          console.log("Error writing private database properties for ", uid);
+        });
+      const memberDatabaseTask = db
+        .collection("members")
+        .doc(uid)
+        .set(member, { merge: true })
+        .catch(function(error) {
+          console.log(error);
+          console.log("Error writing public database properties for ", uid);
+        });
+      return Promise.all([token, memberDatabaseTask, privateDatabaseTask]).then(
+        () => {
+          // Create a Firebase custom auth token.
+          return token;
+        }
+      );
+    });
+  return userTokenTask; //holds value of token
 }

--- a/functions/saveFirestoreDB.js
+++ b/functions/saveFirestoreDB.js
@@ -1,4 +1,4 @@
-const admin = require('firebase-admin');
+const admin = require("firebase-admin");
 
 var serviceAccount = require("./globalnl-database-service-account.json"); // source DB key
 
@@ -11,43 +11,53 @@ const schema = {
   members: {
     current_address: {},
     hometown_address: {}
-    },
+  },
   moderators: {},
   private_data: {
-	interests: {}
+    interests: {}
   }
 };
 
 var db = admin.firestore();
-  const dump = (dbRef, schema, curr) => {
-  return Promise.all(Object.keys(schema).map((collection) => {
-    return dbRef.collection(collection).get()
-      .then((data) => {
-        let promises = [];
-        data.forEach((doc) => {
-          const data = doc.data();
-          if(!curr[collection]) {
-            curr[collection] =  { 
-              data: { },
-              type: 'collection',
-            };
-            curr[collection].data[doc.id] = {
-              data,
-              type: 'document',
+const dump = (dbRef, schema, curr) => {
+  return Promise.all(
+    Object.keys(schema).map(collection => {
+      return dbRef
+        .collection(collection)
+        .get()
+        .then(data => {
+          let promises = [];
+          data.forEach(doc => {
+            const data = doc.data();
+            if (!curr[collection]) {
+              curr[collection] = {
+                data: {},
+                type: "collection"
+              };
+              curr[collection].data[doc.id] = {
+                data,
+                type: "document"
+              };
+            } else {
+              curr[collection].data[doc.id] = data;
             }
-          } else {
-            curr[collection].data[doc.id] = data;
-          }
-          promises.push(dump(dbRef.collection(collection).doc(doc.id), schema[collection], curr[collection].data[doc.id]));
-      })
-      return Promise.all(promises);
-    });
-  })).then(() => {
+            promises.push(
+              dump(
+                dbRef.collection(collection).doc(doc.id),
+                schema[collection],
+                curr[collection].data[doc.id]
+              )
+            );
+          });
+          return Promise.all(promises);
+        });
+    })
+  ).then(() => {
     return curr;
-  })
+  });
 };
 
 let answer = {};
-dump(db, schema, answer).then((answer) => {
+dump(db, schema, answer).then(answer => {
   console.log(JSON.stringify(answer, null, 4));
 });

--- a/public/globalnl.css
+++ b/public/globalnl.css
@@ -24,71 +24,73 @@ body {
 .Absolute-Center {
   margin: auto;
   position: absolute;
-  top: 0; left: 0; bottom: 0; right: 0;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 .Absolute-Center.is-Responsive {
-  width: 100%; 
+  width: 100%;
   height: 100%;
   min-width: 300px;
   max-width: 500px;
   padding: 100px 0px 0px 0px;
 }
 
-#sign-in-button{
+#sign-in-button {
   cursor: pointer;
   max-width: none !important;
 }
 
-#loginPage{
-	display:none;
+#loginPage {
+  display: none;
 }
-#loginPage_text{
-    margin-left:  20px;
-    margin-right:  20px;
-	line-height: 1.2rem;
+#loginPage_text {
+  margin-left: 20px;
+  margin-right: 20px;
+  line-height: 1.2rem;
 }
-#mainPage{
-	display:none;
-	padding: 60px 10px 20px 10px;
+#mainPage {
+  display: none;
+  padding: 60px 10px 20px 10px;
 }
 
 /* Fix double up on navbar */
-@media only screen and (max-width: 970px) and (min-width: 768px){
-	#login_name_nav{
-		display: none;
-	}
-	#linkedin_nav{
-		display: none;
-	}
-	#display_name_label{
-		display: none;
-	}
-	#card-body-bio{
-		padding-top:0px
-	}
+@media only screen and (max-width: 970px) and (min-width: 768px) {
+  #login_name_nav {
+    display: none;
+  }
+  #linkedin_nav {
+    display: none;
+  }
+  #display_name_label {
+    display: none;
+  }
+  #card-body-bio {
+    padding-top: 0px;
+  }
 }
 
-@media only screen and (max-width: 768px){
-	#sign-in-button{
-	  width: 234px;
-	  height: 32px;
-	}
-	#display_name_label{
-		display: none;
-	}
-	#card-body-bio{
-		padding-top:0px
-	}
+@media only screen and (max-width: 768px) {
+  #sign-in-button {
+    width: 234px;
+    height: 32px;
+  }
+  #display_name_label {
+    display: none;
+  }
+  #card-body-bio {
+    padding-top: 0px;
+  }
 }
 
 /* Hide the blue outline in forms */
 .form-control:focus {
-    outline: 0 !important;
-    border-color: initial;
-    box-shadow: none;
+  outline: 0 !important;
+  border-color: initial;
+  box-shadow: none;
 }
-
 
 /* Custom page CSS
 -------------------------------------------------- */
@@ -103,108 +105,105 @@ body {
   padding-left: 15px;
 }
 
-.card-deck{
-	padding-top: 10px;
-	margin: 0px; 
-	/*padding-left: 4px;*/
+.card-deck {
+  padding-top: 10px;
+  margin: 0px;
+  /*padding-left: 4px;*/
 }
 
-.card-deck .card{
-	margin:0px;
+.card-deck .card {
+  margin: 0px;
 }
 
-.card-gnl{
-	width:364px !important;
-	min-width: 364px !important;
-	min-height: 0px;
-	margin:0px;
+.card-gnl {
+  width: 364px !important;
+  min-width: 364px !important;
+  min-height: 0px;
+  margin: 0px;
 }
 
-.card-col{
-	/*padding-top:15px;*/	
+.card-col {
+  /*padding-top:15px;*/
 }
 
 .card-header-gnl {
-    font-weight: 700;
-    font-size: 1.2rem;
-	margin-bottom: 0;
-	padding: .5rem 1rem;
+  font-weight: 700;
+  font-size: 1.2rem;
+  margin-bottom: 0;
+  padding: 0.5rem 1rem;
 }
 
 .card-header-bio {
-	padding-top: 5px;
-	padding-bottom: 5px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .card-body-gnl {
-	padding: 0px;
+  padding: 0px;
 }
 
 .card-body-bio {
-	padding-top: 1rem;
+  padding-top: 1rem;
 }
 
 .card-title {
-	font-weight: 400;
-	font-size: 0.8rem;
-	margin-top: 0.9rem;
-	margin-left: 0.5rem;
-	margin-right: 0.5rem;
-	margin-bottom: 0px;
+  font-weight: 400;
+  font-size: 0.8rem;
+  margin-top: 0.9rem;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  margin-bottom: 0px;
 }
 .card-title-bottom {
-	margin-bottom: 0.9rem;
+  margin-bottom: 0.9rem;
 }
 
 .card-text {
-font-style: italic;
+  font-style: italic;
 }
 
-.btn-gnl{
-	border-top-left-radius: 4px !important;
-    border-bottom-left-radius: 4px !important;
+.btn-gnl {
+  border-top-left-radius: 4px !important;
+  border-bottom-left-radius: 4px !important;
 }
 
 .linkedin_profile_card {
-	margin-top: 0px;
-	margin-bottom: -6px;
-	margin-left: 0px;
-	margin-right: 0px;
+  margin-top: 0px;
+  margin-bottom: -6px;
+  margin-left: 0px;
+  margin-right: 0px;
 }
 
-.fa-globalnl{
-    margin-right: 0.2rem;
-    margin-left: 0.2rem;
-	width: 1.6rem;
-	text-align: center;
-	
+.fa-globalnl {
+  margin-right: 0.2rem;
+  margin-left: 0.2rem;
+  width: 1.6rem;
+  text-align: center;
 }
 
-.fa-gnl-map{
-    margin-right: 0.2rem;
-	width: 1.0rem;
-	text-align: center;
-	
+.fa-gnl-map {
+  margin-right: 0.2rem;
+  width: 1rem;
+  text-align: center;
 }
 
-.fa-gnl-head{
-	padding-right: 10px;
+.fa-gnl-head {
+  padding-right: 10px;
 }
 
-.fa-gnlsearch{
-	font-size:1.5rem;
-	text-align: center;
+.fa-gnlsearch {
+  font-size: 1.5rem;
+  text-align: center;
 }
 
-.form-row{	
-	padding-left: 14px;
-	padding-right: 14px;
+.form-row {
+  padding-left: 14px;
+  padding-right: 14px;
 }
 
-.input-group-prepend{
-	/*width: 43px;*/
+.input-group-prepend {
+  /*width: 43px;*/
 }
-
 
 /* LinkedIn On/Off toggle button */
 
@@ -214,12 +213,14 @@ font-style: italic;
   display: inline-block;
   width: 44px;
   height: 24px;
-  margin-left:0px;
-  margin-bottom:0px;
+  margin-left: 0px;
+  margin-bottom: 0px;
 }
 
 /* Hide default HTML checkbox */
-.switch input {display:none;}
+.switch input {
+  display: none;
+}
 
 /* The slider */
 .slider {
@@ -229,13 +230,13 @@ font-style: italic;
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(255,255,255,.5);
-  -webkit-transition: .4s;
-  transition: .4s;
+  background-color: rgba(255, 255, 255, 0.5);
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
 }
 
-.slider:hover{
-  background-color: rgba(255,255,255,.75);	
+.slider:hover {
+  background-color: rgba(255, 255, 255, 0.75);
 }
 
 .slider:before {
@@ -246,12 +247,12 @@ font-style: italic;
   left: 2px;
   bottom: 2px;
   background-color: #007bff;
-  -webkit-transition: .4s;
-  transition: .4s;
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
 }
 
 input:checked + .slider {
-  background-color: rgba(255,255,255,.75);
+  background-color: rgba(255, 255, 255, 0.75);
 }
 
 input:focus + .slider {

--- a/public/gnl.js
+++ b/public/gnl.js
@@ -1,0 +1,17 @@
+// Temporary place to expose shared functions until the
+// rest of the codebase has been moved into modules.
+window.gnl = (function () {
+  const auth = {};
+
+  auth.loginLinkedIn = function () {
+    window.open(
+      "login.html",
+      "targetWindow",
+      "toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=no,width=585,height=600"
+    );
+  };
+
+  return {
+    auth: auth
+  };
+}());

--- a/public/gnl.js
+++ b/public/gnl.js
@@ -1,9 +1,9 @@
 // Temporary place to expose shared functions until the
 // rest of the codebase has been moved into modules.
-window.gnl = (function () {
+window.gnl = (function() {
   const auth = {};
 
-  auth.loginLinkedIn = function () {
+  auth.loginLinkedIn = function() {
     window.open(
       "login.html",
       "targetWindow",
@@ -11,15 +11,15 @@ window.gnl = (function () {
     );
   };
 
-  auth.logout = function () {
+  auth.logout = function() {
     firebase
       .auth()
       .signOut()
       .then(
-        function () {
+        function() {
           console.log("Signed Out");
         },
-        function (error) {
+        function(error) {
           console.error("Sign Out Error", error);
         }
       );
@@ -58,15 +58,23 @@ window.gnl = (function () {
   </li>
   `;
 
-  auth.listenForStageChange = function (renderWithUser, renderWithoutUser, displayLinkedInToggle) {
-    firebase.auth().onAuthStateChanged(function (user) {
+  auth.listenForStageChange = function(
+    renderWithUser,
+    renderWithoutUser,
+    displayLinkedInToggle
+  ) {
+    firebase.auth().onAuthStateChanged(function(user) {
       if (user) {
-        $("#userNavBar").html(displayLinkedInToggle ? (linkedInToggleUserBar + loggedInUserBar) : loggedInUserBar);
+        $("#userNavBar").html(
+          displayLinkedInToggle
+            ? linkedInToggleUserBar + loggedInUserBar
+            : loggedInUserBar
+        );
         $("#loginPage").hide();
 
         // Load user information at top of page for desktop
         $("#login_name").html(user.displayName);
-        $("#button_logout").click(function (evt) {
+        $("#button_logout").click(function(evt) {
           // Cancel the default action
           evt.preventDefault();
           gnl.auth.logout();
@@ -89,7 +97,7 @@ window.gnl = (function () {
 
   const navBar = {};
 
-  navBar.toggle = function () {
+  navBar.toggle = function() {
     if ($(".navbar-toggler").css("display") !== "none") {
       $(".navbar-toggler").trigger("click");
     }

--- a/public/gnl.js
+++ b/public/gnl.js
@@ -25,7 +25,16 @@ window.gnl = (function () {
       );
   }
 
+  const navBar = {};
+
+  navBar.toggle = function () {
+    if ($(".navbar-toggler").css("display") !== "none") {
+      $(".navbar-toggler").trigger("click");
+    }
+  }
+
   return {
-    auth: auth
+    auth: auth,
+    navBar: navBar
   };
 }());

--- a/public/gnl.js
+++ b/public/gnl.js
@@ -25,10 +25,43 @@ window.gnl = (function () {
       );
   };
 
-  auth.listenForStageChange = function (renderWithUser, renderWithoutUser) {
+  const defaultUserBar = `
+  <li class="nav-item">
+    <a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();gnl.navBar.toggle();return false;">
+      <span class="fas fa-globalnl fa-user"></span>
+      <span>Sign in</span>
+    </a>
+  </li>
+  `;
+
+  const linkedInToggleUserBar = `
+  <li class="nav-item" id="linkedin_nav">
+    <a class="nav-link" style="padding:8px 8px 0px 0px;" href="#">
+      <span style="vertical-align:top; margin-top:5px;" class="fab fa-globalnl fa-linkedin-in"></span>
+      <label class="switch">
+        <input id="linkedin_toggle" checked type="checkbox">
+        <span class="slider round"></span>
+      </label>
+    </a>
+  </li>
+  `;
+
+  const loggedInUserBar = `
+  <li class="nav-item" id="login_name_nav">
+    <a class="nav-link" href="#"><span class="fas fa-globalnl fa-user"></span><span id="login_name"></span></a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="profile.html"><span class="fas fa-globalnl fa-edit"></span><span>Edit profile</span></a>
+  </li>
+  <li id="button_logout" class="nav-item">
+    <a class="nav-link" href="#"><span class="fas fa-globalnl fa-sign-out-alt"></span><span>Logout</span></a>
+  </li>
+  `;
+
+  auth.listenForStageChange = function (renderWithUser, renderWithoutUser, displayLinkedInToggle) {
     firebase.auth().onAuthStateChanged(function (user) {
       if (user) {
-        $("#userNavBar").html(loggedinUserBar);
+        $("#userNavBar").html(displayLinkedInToggle ? (linkedInToggleUserBar + loggedInUserBar) : loggedInUserBar);
         $("#loginPage").hide();
 
         // Load user information at top of page for desktop

--- a/public/gnl.js
+++ b/public/gnl.js
@@ -11,6 +11,20 @@ window.gnl = (function () {
     );
   };
 
+  auth.logout = function () {
+    firebase
+      .auth()
+      .signOut()
+      .then(
+        function () {
+          console.log("Signed Out");
+        },
+        function (error) {
+          console.error("Sign Out Error", error);
+        }
+      );
+  }
+
   return {
     auth: auth
   };

--- a/public/gnl.js
+++ b/public/gnl.js
@@ -23,7 +23,36 @@ window.gnl = (function () {
           console.error("Sign Out Error", error);
         }
       );
-  }
+  };
+
+  auth.listenForStageChange = function (renderWithUser, renderWithoutUser) {
+    firebase.auth().onAuthStateChanged(function (user) {
+      if (user) {
+        $("#userNavBar").html(loggedinUserBar);
+        $("#loginPage").hide();
+
+        // Load user information at top of page for desktop
+        $("#login_name").html(user.displayName);
+        $("#button_logout").click(function (evt) {
+          // Cancel the default action
+          evt.preventDefault();
+          gnl.auth.logout();
+          gnl.navBar.toggle();
+        });
+
+        if (renderWithUser) {
+          renderWithUser(user);
+        }
+      } else {
+        $("#userNavBar").html(defaultUserBar);
+        $("#loginPage").show();
+
+        if (renderWithoutUser) {
+          renderWithoutUser(user);
+        }
+      }
+    });
+  };
 
   const navBar = {};
 
@@ -31,10 +60,10 @@ window.gnl = (function () {
     if ($(".navbar-toggler").css("display") !== "none") {
       $(".navbar-toggler").trigger("click");
     }
-  }
+  };
 
   return {
     auth: auth,
     navBar: navBar
   };
-}());
+})();

--- a/public/index.html
+++ b/public/index.html
@@ -17,8 +17,8 @@
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.1/css/bootstrap.min.css">
 		
 		<!-- Custom CSS -->
-		<link rel="stylesheet" href="globalnl.css">		
-		<link rel="stylesheet" href="vTabs.css">			
+		<link rel="stylesheet" href="globalnl.css">
+		<link rel="stylesheet" href="vTabs.css">
 
 		<style>
 		#mainPage{
@@ -51,7 +51,7 @@
             </li>
           </ul>
 		  <ul id="userNavBar" class="nav navbar-nav navbar-right">
-			<li class="nav-item"><a class="nav-link" href="#" onClick="LIlogin();clickNavBar();return false;"><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>
+			<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();clickNavBar();return false;"><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>
 		</ul>
 	
       </nav>
@@ -67,7 +67,7 @@
 			   to continue to the Global NL Members Portal
 			  </p>  
 			  </div>
-			  <img class="mx-auto d-block" alt="Sign in with LinkedIn" id="sign-in-button" onClick="LIlogin();return false;" 
+			  <img class="mx-auto d-block" alt="Sign in with LinkedIn" id="sign-in-button" onClick="gnl.auth.loginLinkedIn();return false;" 
 			  src="assets/Sign-In-Small---Default.png" onmouseover="this.src='assets/Sign-In-Small---Hover.png'" onmouseout="this.src='assets/Sign-In-Small---Default.png'"/>
         <div class="w-100 m-2"></div>
       <div id="loginPage_text" class="text-center">
@@ -240,6 +240,7 @@
 	<script src="//platform.linkedin.com/in.js" type="text/javascript"></script>
 
 	<!-- Site source, handlers and interfaces first, then the page code -->
+	<script type="text/javascript" src="gnl.js"></script>
 	<script type="text/javascript" src="index.js"></script>
 	 
 	 <!-- auto complete from google maps must be called after members.js -->

--- a/public/index.html
+++ b/public/index.html
@@ -51,7 +51,7 @@
             </li>
           </ul>
 		  <ul id="userNavBar" class="nav navbar-nav navbar-right">
-			<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();clickNavBar();return false;"><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>
+			<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();gnl.navBar.toggle();return false;"><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>
 		</ul>
 	
       </nav>

--- a/public/index.js
+++ b/public/index.js
@@ -2,21 +2,6 @@
  * Global variables
  ******************************************************/
 
-const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();gnl.navBar.toggle();return false;" ><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>`;
-
-const loggedinUserBar = `<li class="nav-item" id="linkedin_nav">
-			<a class="nav-link" style="padding:8px 8px 0px 0px;" href="#">
-				<span style="vertical-align:top; margin-top:5px;" class="fab fa-globalnl fa-linkedin-in"></span>
-		  	  	<label class="switch">
-				  <input id="linkedin_toggle" checked type="checkbox">
-				  <span class="slider round"></span>
-				</label>
-			</a>
-		  </li>
-			<li class="nav-item" id="login_name_nav"><a class="nav-link" href="#"><span class="fas fa-globalnl fa-user"></span><span id="login_name"></span></a></li>
-			<li class="nav-item"><a class="nav-link" href="profile.html"><span class="fas fa-globalnl fa-edit"></span><span id="">Edit profile</span></a></li>
-			<li id="button_logout" class="nav-item"><a class="nav-link" href="#"><span class="fas fa-globalnl fa-sign-out-alt"></span><span id="">Logout</span></a></li>`;
-
 // Disable LinkedIn banners via toggle button
 var LinkedInEnable = true;
 
@@ -50,7 +35,7 @@ function renderWithUser(user) {
   $("#members-list").empty();
   $("#mainPage").show();
   initLoad();
-  $("#linkedin_toggle").change(function() {
+  $("#linkedin_toggle").change(function () {
     if ($("#linkedin_toggle:checked").val() == "on") {
       LinkedInEnable = true;
     } else {
@@ -64,20 +49,20 @@ function renderWithoutUser() {
   $("#mainPage").hide();
 }
 
-gnl.auth.listenForStageChange(renderWithUser, renderWithoutUser);
+gnl.auth.listenForStageChange(renderWithUser, renderWithoutUser, true);
 
 /*****************************************************
  * Register event callbacks & implement element callbacks
  ******************************************************/
 // Init auth on load web page event
-$(document).ready(function() {
+$(document).ready(function () {
   $("#preloader").hide();
   initApp();
 });
 
 // Callback executed on page load
 function initApp() {
-  $(window).scroll(function() {
+  $(window).scroll(function () {
     if (scrollQueryComplete) {
       if (
         $(window).scrollTop() >
@@ -90,7 +75,7 @@ function initApp() {
     }
   });
 
-  $("#form_name").submit(function(event) {
+  $("#form_name").submit(function (event) {
     event.preventDefault();
     if ($("#inputFirstName").val() || $("#inputLastName").val()) {
       console.log("Searching by name...");
@@ -124,7 +109,7 @@ function initApp() {
     }
   });
 
-  $("#form_location").submit(function(event) {
+  $("#form_location").submit(function (event) {
     event.preventDefault();
     if ($("#autocomplete_current").val()) {
       console.log("Searching by location...");
@@ -146,7 +131,7 @@ function initApp() {
     }
   });
 
-  $("#form_industry").submit(function(event) {
+  $("#form_industry").submit(function (event) {
     event.preventDefault();
     if ($("#inputIndustry").val()) {
       console.log("Searching by industry...");
@@ -162,7 +147,7 @@ function initApp() {
     }
   });
 
-  $("#form_hometown").submit(function(event) {
+  $("#form_hometown").submit(function (event) {
     event.preventDefault();
     if ($("#autocomplete_hometown").val()) {
       console.log("Searching by hometown / NL roots...");
@@ -184,7 +169,7 @@ function initApp() {
     }
   });
 
-  $(".clear_button").click(function(event) {
+  $(".clear_button").click(function (event) {
     console.log("Clear search...");
     $("#preloader").show();
     $("#form_name")
@@ -276,7 +261,7 @@ function initLoad() {
     .startAt("A")
     .limit(members_per_page)
     .get()
-    .then(function(querySnapshot) {
+    .then(function (querySnapshot) {
       loadMembers(querySnapshot);
     });
 
@@ -293,7 +278,7 @@ function profile() {
 function loadMembers(querySnapshot) {
   if (querySnapshot.docs.length > 0) {
     last_read_doc = querySnapshot.docs[querySnapshot.docs.length - 1];
-    querySnapshot.forEach(function(doc) {
+    querySnapshot.forEach(function (doc) {
       // doc.data() is never undefined for query doc snapshots
 
       // copied_account set if old account migrated over - need to manually delete these
@@ -321,36 +306,36 @@ function loadMembers(querySnapshot) {
         memberDomString = `<div class="col-auto p-1 card-col">
 <div id="${memberFields.public_uid}" class="card card-gnl">
 	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${
-    memberFields.firstName
-  } ${memberFields.lastName}</div>
+          memberFields.firstName
+          } ${memberFields.lastName}</div>
 	<div class="card-body card-body-gnl">
 	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${
-    memberFields.currentAddress
-  }</h5>
+          memberFields.currentAddress
+          }</h5>
 	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${
-    memberFields.industry
-  }</h5>
+          memberFields.industry
+          }</h5>
 	<h5 class="card-title"><span class="fas fa-globalnl fa-anchor"></span>${
-    memberFields.hometown
-  }</h5>
+          memberFields.hometown
+          }</h5>
 	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-info-circle"></span>${
-    memberFields.bio
-  }</h5>
+          memberFields.bio
+          }</h5>
 	<div class="linkedin_profile_card">
 	<script type="IN/MemberProfile" data-id="${
-    memberFields.linkedin_profile
-  }" data-format="inline" data-related="false"></script>
+          memberFields.linkedin_profile
+          }" data-format="inline" data-related="false"></script>
 	</div>
   </div>
 </div>
 </div>`;
         console.log(
           "Loaded profile: " +
-            doc.data().first_name +
-            "  -  " +
-            doc.data().linkedin_profile +
-            "  -  " +
-            doc.id
+          doc.data().first_name +
+          "  -  " +
+          doc.data().linkedin_profile +
+          "  -  " +
+          doc.id
         );
       } else if (
         doc.data().linkedin_profile &&
@@ -360,86 +345,86 @@ function loadMembers(querySnapshot) {
         memberDomString = `<div class="col-auto p-1 card-col">
 <div id="${memberFields.public_uid}" class="card card-gnl">
 	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${
-    memberFields.firstName
-  } ${memberFields.lastName}</div>
+          memberFields.firstName
+          } ${memberFields.lastName}</div>
 	<div class="card-body card-body-gnl">
 	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${
-    memberFields.currentAddress
-  }</h5>
+          memberFields.currentAddress
+          }</h5>
 	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${
-    memberFields.industry
-  }</h5>
+          memberFields.industry
+          }</h5>
 	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-anchor"></span>${
-    memberFields.hometown
-  }</h5>
+          memberFields.hometown
+          }</h5>
 	<div class="linkedin_profile_card">
 	<script type="IN/MemberProfile" data-id="${
-    memberFields.linkedin_profile
-  }" data-format="inline" data-related="false"></script>
+          memberFields.linkedin_profile
+          }" data-format="inline" data-related="false"></script>
 	</div>
   </div>
 </div>
 </div>`;
         console.log(
           "Loaded profile: " +
-            doc.data().first_name +
-            "  -  " +
-            doc.data().linkedin_profile +
-            "  -  " +
-            doc.id
+          doc.data().first_name +
+          "  -  " +
+          doc.data().linkedin_profile +
+          "  -  " +
+          doc.id
         );
       } else if (memberFields.bio) {
         memberDomString = `<div class="col-auto p-1 card-col">
 <div id="{[0](public_uid)}" class="card card-gnl">
 	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${
-    memberFields.firstName
-  } ${memberFields.lastName}</div>
+          memberFields.firstName
+          } ${memberFields.lastName}</div>
 	<div class="card-body card-body-gnl">
 	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${
-    memberFields.currentAddress
-  }</h5>
+          memberFields.currentAddress
+          }</h5>
 	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${
-    memberFields.industry
-  }</h5>
+          memberFields.industry
+          }</h5>
 	<h5 class="card-title"><span class="fas fa-globalnl fa-anchor"></span>${
-    memberFields.hometown
-  }</h5>
+          memberFields.hometown
+          }</h5>
 	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-info-circle"></span>${
-    memberFields.bio
-  }</h5>
+          memberFields.bio
+          }</h5>
   </div>
 </div>
 </div>`;
         console.log(
           "Loaded profile: " +
-            doc.data().first_name +
-            "  -  No LinkedIn  -  " +
-            doc.id
+          doc.data().first_name +
+          "  -  No LinkedIn  -  " +
+          doc.id
         );
       } else {
         memberDomString = `<div class="col-auto p-1 card-col">
 <div id="{[0](public_uid)}" class="card card-gnl">
 	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${
-    memberFields.firstName
-  } ${memberFields.lastName}</div>
+          memberFields.firstName
+          } ${memberFields.lastName}</div>
 	<div class="card-body card-body-gnl">
 	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${
-    memberFields.currentAddress
-  }</h5>
+          memberFields.currentAddress
+          }</h5>
 	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${
-    memberFields.industry
-  }</h5>
+          memberFields.industry
+          }</h5>
 	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-anchor"></span>${
-    memberFields.hometown
-  }</h5>
+          memberFields.hometown
+          }</h5>
   </div>
 </div>
 </div>`;
         console.log(
           "Loaded profile: " +
-            doc.data().first_name +
-            "  -  No LinkedIn  -  " +
-            doc.id
+          doc.data().first_name +
+          "  -  No LinkedIn  -  " +
+          doc.id
         );
       }
       var memObj = $.parseHTML(memberDomString);
@@ -480,7 +465,7 @@ function memberSearch() {
         .where("first_name", "==", formStatic["name"]["first"])
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["name"]["last"]) {
@@ -491,7 +476,7 @@ function memberSearch() {
         .where("last_name", "==", formStatic["name"]["last"])
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["name"]["first"]) {
@@ -503,7 +488,7 @@ function memberSearch() {
         .where("first_name", "==", formStatic["name"]["first"])
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else {
@@ -520,7 +505,7 @@ function memberSearch() {
         .where("first_name", "==", formStatic["name"]["first"])
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["name"]["last"]) {
@@ -530,7 +515,7 @@ function memberSearch() {
         .where("last_name", "==", formStatic["name"]["last"])
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["name"]["first"]) {
@@ -541,7 +526,7 @@ function memberSearch() {
         .where("first_name", "==", formStatic["name"]["first"])
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else {
@@ -569,7 +554,7 @@ function memberSearch() {
         )
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["location"]["prov"]) {
@@ -590,7 +575,7 @@ function memberSearch() {
         )
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["location"]["country"]) {
@@ -606,7 +591,7 @@ function memberSearch() {
         )
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else {
@@ -634,7 +619,7 @@ function memberSearch() {
         .startAfter(last_read_doc)
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["location"]["prov"]) {
@@ -655,7 +640,7 @@ function memberSearch() {
         .startAfter(last_read_doc)
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["location"]["country"]) {
@@ -671,7 +656,7 @@ function memberSearch() {
         .startAfter(last_read_doc)
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else {
@@ -689,7 +674,7 @@ function memberSearch() {
         .where("industry", "==", formStatic["industry"])
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     }
@@ -704,7 +689,7 @@ function memberSearch() {
         .where("industry", "==", formStatic["industry"])
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     }
@@ -733,7 +718,7 @@ function memberSearch() {
         )
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["hometown"]["prov"]) {
@@ -754,7 +739,7 @@ function memberSearch() {
         )
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["hometown"]["country"]) {
@@ -770,7 +755,7 @@ function memberSearch() {
         )
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else {
@@ -802,7 +787,7 @@ function memberSearch() {
         .startAfter(last_read_doc)
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["hometown"]["prov"]) {
@@ -823,7 +808,7 @@ function memberSearch() {
         .startAfter(last_read_doc)
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["hometown"]["country"]) {
@@ -839,7 +824,7 @@ function memberSearch() {
         .startAfter(last_read_doc)
         .limit(members_per_page)
         .get()
-        .then(function(querySnapshot) {
+        .then(function (querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else {
@@ -852,7 +837,7 @@ function memberSearch() {
       .startAfter(last_read_doc)
       .limit(members_per_page)
       .get()
-      .then(function(querySnapshot) {
+      .then(function (querySnapshot) {
         loadMembers(querySnapshot);
       });
   }
@@ -870,7 +855,7 @@ function getLocationString(locationObject) {
 
     if (
       locationObject.administrative_area_level_1 ==
-        "Newfoundland and Labrador" &&
+      "Newfoundland and Labrador" &&
       locationObject.locality
     ) {
       // Append all required data to array
@@ -926,13 +911,13 @@ function initAutocomplete() {
   // Register our autocomplete elements, see URL for more information
   // https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
   autocomplete_current = new google.maps.places.Autocomplete(
-    /** @type {!HTMLInputElement} */ (document.getElementById(
+    /** @type {!HTMLInputElement} */(document.getElementById(
       "autocomplete_current"
     )),
     { types: ["geocode"] }
   );
   autocomplete_hometown = new google.maps.places.Autocomplete(
-    /** @type {!HTMLInputElement} */ (document.getElementById(
+    /** @type {!HTMLInputElement} */(document.getElementById(
       "autocomplete_hometown"
     )),
     { types: ["geocode"] }
@@ -951,7 +936,7 @@ function initAutocomplete() {
 
   // define event callbacks for each element, these fire when the fields
   // are auto filled by google api and then the location data is stored in our member object
-  autocomplete_current.addListener("place_changed", function() {
+  autocomplete_current.addListener("place_changed", function () {
     try {
       // Get place object from google api
       var place = autocomplete_current.getPlace();
@@ -983,7 +968,7 @@ function initAutocomplete() {
 
   // Second autocomplete callback, the repeated code kills me but im currently lazy
   // TODO: tear out the repeated code into a function above
-  autocomplete_hometown.addListener("place_changed", function() {
+  autocomplete_hometown.addListener("place_changed", function () {
     try {
       // Get place object from google api
       var place = autocomplete_hometown.getPlace();

--- a/public/index.js
+++ b/public/index.js
@@ -905,71 +905,17 @@ function getLocationString(locationObject) {
   }
 }
 
-// Look for these keys in the place object returned by google API
-// if found, their values are filled and written to our new member object
-const locationData = {
-  street_number: true,
-  route: true,
-  locality: true,
-  administrative_area_level_1: true,
-  country: true,
-  postal_code: true
-};
-
-// Iterate over object and look for the keys in locationData
-function parsePlace(place) {
-  const parsed = {
-    administrative_area_level_1: null,
-    country: null,
-    lat: null,
-    lng: null,
-    locality: null
-  };
-
-  for (let i = 0; i < place.address_components.length; i++) {
-    const addressType = place.address_components[i].types[0];
-    if (locationData.hasOwnProperty(addressType)) {
-      parsed[addressType] = place.address_components[i]["long_name"];
-    }
-  }
-
-  // Store geometry into new member object as well
-  parsed.lat = place.geometry.location.lat();
-  parsed.lng = place.geometry.location.lng();
-
-  return parsed;
-}
-
-function addPlaceChangedListener(autocomplete, fieldName) {
-  autocomplete.addListener("place_changed", function() {
-    try {
-      // Get place object from google api
-      const place = autocomplete.getPlace();
-      if (place) {
-        formDynamic[fieldName] = parsePlace(place);
-      }
-    } catch (err) {
-      console.log(err);
-    }
-  });
-}
-
 // Callback for google maps autocomplete for storing autocompleted location data into
 // the new member objcet
 function initAutocomplete() {
-  // Register our autocomplete elements, see URL for more information
-  // https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
-  autocomplete_current = new google.maps.places.Autocomplete(
-    document.getElementById("autocomplete_current"),
-    { types: ["geocode"] }
+  gnl.location.bindAutocomplete(
+    formDynamic,
+    "autocomplete_current",
+    "current_address"
   );
-  autocomplete_hometown = new google.maps.places.Autocomplete(
-    document.getElementById("autocomplete_hometown"),
-    { types: ["geocode"] }
+  gnl.location.bindAutocomplete(
+    formDynamic,
+    "autocomplete_hometown",
+    "hometown_address"
   );
-
-  // Define event callbacks for each element, these fire when the fields
-  // are auto filled by google api and then the location data is stored in our member object
-  addPlaceChangedListener(autocomplete_current, "current_address");
-  addPlaceChangedListener(autocomplete_hometown, "hometown_address");
 }

--- a/public/index.js
+++ b/public/index.js
@@ -67,7 +67,7 @@ firebase.auth().onAuthStateChanged(function(user) {
     $("#button_logout").click(function(e) {
       // Cancel the default action
       e.preventDefault();
-      logout();
+      gnl.auth.logout();
       clickNavBar();
     });
   } else {
@@ -231,7 +231,7 @@ function initLoad() {
     .then(doc => {
       if (!doc.exists) {
         console.log("User does not exist in database");
-        logout();
+        gnl.auth.logout();
       } else {
         if (!doc.data().date_updated || doc.data().date_updated == "-1") {
           window.location.href = "profile.html";
@@ -298,22 +298,6 @@ function initLoad() {
 function profile() {
   console.log("Nav profile.html");
   window.location.href = "profile.html";
-}
-
-// Logout callback
-function logout() {
-  firebase
-    .auth()
-    .signOut()
-    .then(
-      function() {
-        console.log("Signed Out");
-        //window.location.href = "index.html";
-      },
-      function(error) {
-        console.error("Sign Out Error", error);
-      }
-    );
 }
 
 function clickNavBar() {

--- a/public/index.js
+++ b/public/index.js
@@ -46,36 +46,25 @@ firebase.firestore().settings(settings);
 var fbi = firebase.firestore().collection("members");
 //var uid = firebase.auth().currentUser.uid;
 
-firebase.auth().onAuthStateChanged(function(user) {
+function renderWithUser(user) {
   $("#members-list").empty();
-  if (user) {
-    // User logged in.
-    $("#userNavBar").html(loggedinUserBar);
-    $("#loginPage").hide();
-    $("#mainPage").show();
-    initLoad();
-    // Load user information at top of page for desktop
-    $("#login_name").html(firebase.auth().currentUser.displayName);
-    $("#linkedin_toggle").change(function() {
-      if ($("#linkedin_toggle:checked").val() == "on") {
-        LinkedInEnable = true;
-      } else {
-        LinkedInEnable = false;
-      }
-    });
+  $("#mainPage").show();
+  initLoad();
+  $("#linkedin_toggle").change(function() {
+    if ($("#linkedin_toggle:checked").val() == "on") {
+      LinkedInEnable = true;
+    } else {
+      LinkedInEnable = false;
+    }
+  });
+}
 
-    $("#button_logout").click(function(e) {
-      // Cancel the default action
-      e.preventDefault();
-      gnl.auth.logout();
-      gnl.navBar.toggle();
-    });
-  } else {
-    $("#userNavBar").html(defaultUserBar);
-    $("#mainPage").hide();
-    $("#loginPage").show();
-  }
-});
+function renderWithoutUser() {
+  $("#members-list").empty();
+  $("#mainPage").hide();
+}
+
+gnl.auth.listenForStageChange(renderWithUser, renderWithoutUser);
 
 /*****************************************************
  * Register event callbacks & implement element callbacks

--- a/public/index.js
+++ b/public/index.js
@@ -2,7 +2,7 @@
  * Global variables
  ******************************************************/
 
-const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();clickNavBar();return false;" ><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>`;
+const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();gnl.navBar.toggle();return false;" ><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>`;
 
 const loggedinUserBar = `<li class="nav-item" id="linkedin_nav">
 			<a class="nav-link" style="padding:8px 8px 0px 0px;" href="#">
@@ -68,7 +68,7 @@ firebase.auth().onAuthStateChanged(function(user) {
       // Cancel the default action
       e.preventDefault();
       gnl.auth.logout();
-      clickNavBar();
+      gnl.navBar.toggle();
     });
   } else {
     $("#userNavBar").html(defaultUserBar);
@@ -300,14 +300,7 @@ function profile() {
   window.location.href = "profile.html";
 }
 
-function clickNavBar() {
-  if ($(".navbar-toggler").css("display") != "none") {
-    $(".navbar-toggler").trigger("click");
-  }
-}
-
-/* load members
-*/
+/* load members */
 function loadMembers(querySnapshot) {
   if (querySnapshot.docs.length > 0) {
     last_read_doc = querySnapshot.docs[querySnapshot.docs.length - 1];

--- a/public/index.js
+++ b/public/index.js
@@ -2,7 +2,7 @@
  * Global variables
  ******************************************************/
 
-const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="LIlogin();clickNavBar();return false;" ><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>`;
+const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();clickNavBar();return false;" ><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>`;
 
 const loggedinUserBar = `<li class="nav-item" id="linkedin_nav">
 			<a class="nav-link" style="padding:8px 8px 0px 0px;" href="#">
@@ -76,14 +76,6 @@ firebase.auth().onAuthStateChanged(function(user) {
     $("#loginPage").show();
   }
 });
-
-function LIlogin() {
-  window.open(
-    "login.html",
-    "targetWindow",
-    "toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=no,width=585,height=600"
-  );
-}
 
 /*****************************************************
  * Register event callbacks & implement element callbacks

--- a/public/index.js
+++ b/public/index.js
@@ -35,7 +35,7 @@ function renderWithUser(user) {
   $("#members-list").empty();
   $("#mainPage").show();
   initLoad();
-  $("#linkedin_toggle").change(function () {
+  $("#linkedin_toggle").change(function() {
     if ($("#linkedin_toggle:checked").val() == "on") {
       LinkedInEnable = true;
     } else {
@@ -55,14 +55,14 @@ gnl.auth.listenForStageChange(renderWithUser, renderWithoutUser, true);
  * Register event callbacks & implement element callbacks
  ******************************************************/
 // Init auth on load web page event
-$(document).ready(function () {
+$(document).ready(function() {
   $("#preloader").hide();
   initApp();
 });
 
 // Callback executed on page load
 function initApp() {
-  $(window).scroll(function () {
+  $(window).scroll(function() {
     if (scrollQueryComplete) {
       if (
         $(window).scrollTop() >
@@ -75,7 +75,7 @@ function initApp() {
     }
   });
 
-  $("#form_name").submit(function (event) {
+  $("#form_name").submit(function(event) {
     event.preventDefault();
     if ($("#inputFirstName").val() || $("#inputLastName").val()) {
       console.log("Searching by name...");
@@ -109,7 +109,7 @@ function initApp() {
     }
   });
 
-  $("#form_location").submit(function (event) {
+  $("#form_location").submit(function(event) {
     event.preventDefault();
     if ($("#autocomplete_current").val()) {
       console.log("Searching by location...");
@@ -131,7 +131,7 @@ function initApp() {
     }
   });
 
-  $("#form_industry").submit(function (event) {
+  $("#form_industry").submit(function(event) {
     event.preventDefault();
     if ($("#inputIndustry").val()) {
       console.log("Searching by industry...");
@@ -147,7 +147,7 @@ function initApp() {
     }
   });
 
-  $("#form_hometown").submit(function (event) {
+  $("#form_hometown").submit(function(event) {
     event.preventDefault();
     if ($("#autocomplete_hometown").val()) {
       console.log("Searching by hometown / NL roots...");
@@ -169,7 +169,7 @@ function initApp() {
     }
   });
 
-  $(".clear_button").click(function (event) {
+  $(".clear_button").click(function(event) {
     console.log("Clear search...");
     $("#preloader").show();
     $("#form_name")
@@ -261,7 +261,7 @@ function initLoad() {
     .startAt("A")
     .limit(members_per_page)
     .get()
-    .then(function (querySnapshot) {
+    .then(function(querySnapshot) {
       loadMembers(querySnapshot);
     });
 
@@ -278,7 +278,7 @@ function profile() {
 function loadMembers(querySnapshot) {
   if (querySnapshot.docs.length > 0) {
     last_read_doc = querySnapshot.docs[querySnapshot.docs.length - 1];
-    querySnapshot.forEach(function (doc) {
+    querySnapshot.forEach(function(doc) {
       // doc.data() is never undefined for query doc snapshots
 
       // copied_account set if old account migrated over - need to manually delete these
@@ -306,36 +306,36 @@ function loadMembers(querySnapshot) {
         memberDomString = `<div class="col-auto p-1 card-col">
 <div id="${memberFields.public_uid}" class="card card-gnl">
 	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${
-          memberFields.firstName
-          } ${memberFields.lastName}</div>
+    memberFields.firstName
+  } ${memberFields.lastName}</div>
 	<div class="card-body card-body-gnl">
 	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${
-          memberFields.currentAddress
-          }</h5>
+    memberFields.currentAddress
+  }</h5>
 	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${
-          memberFields.industry
-          }</h5>
+    memberFields.industry
+  }</h5>
 	<h5 class="card-title"><span class="fas fa-globalnl fa-anchor"></span>${
-          memberFields.hometown
-          }</h5>
+    memberFields.hometown
+  }</h5>
 	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-info-circle"></span>${
-          memberFields.bio
-          }</h5>
+    memberFields.bio
+  }</h5>
 	<div class="linkedin_profile_card">
 	<script type="IN/MemberProfile" data-id="${
-          memberFields.linkedin_profile
-          }" data-format="inline" data-related="false"></script>
+    memberFields.linkedin_profile
+  }" data-format="inline" data-related="false"></script>
 	</div>
   </div>
 </div>
 </div>`;
         console.log(
           "Loaded profile: " +
-          doc.data().first_name +
-          "  -  " +
-          doc.data().linkedin_profile +
-          "  -  " +
-          doc.id
+            doc.data().first_name +
+            "  -  " +
+            doc.data().linkedin_profile +
+            "  -  " +
+            doc.id
         );
       } else if (
         doc.data().linkedin_profile &&
@@ -345,86 +345,86 @@ function loadMembers(querySnapshot) {
         memberDomString = `<div class="col-auto p-1 card-col">
 <div id="${memberFields.public_uid}" class="card card-gnl">
 	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${
-          memberFields.firstName
-          } ${memberFields.lastName}</div>
+    memberFields.firstName
+  } ${memberFields.lastName}</div>
 	<div class="card-body card-body-gnl">
 	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${
-          memberFields.currentAddress
-          }</h5>
+    memberFields.currentAddress
+  }</h5>
 	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${
-          memberFields.industry
-          }</h5>
+    memberFields.industry
+  }</h5>
 	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-anchor"></span>${
-          memberFields.hometown
-          }</h5>
+    memberFields.hometown
+  }</h5>
 	<div class="linkedin_profile_card">
 	<script type="IN/MemberProfile" data-id="${
-          memberFields.linkedin_profile
-          }" data-format="inline" data-related="false"></script>
+    memberFields.linkedin_profile
+  }" data-format="inline" data-related="false"></script>
 	</div>
   </div>
 </div>
 </div>`;
         console.log(
           "Loaded profile: " +
-          doc.data().first_name +
-          "  -  " +
-          doc.data().linkedin_profile +
-          "  -  " +
-          doc.id
+            doc.data().first_name +
+            "  -  " +
+            doc.data().linkedin_profile +
+            "  -  " +
+            doc.id
         );
       } else if (memberFields.bio) {
         memberDomString = `<div class="col-auto p-1 card-col">
 <div id="{[0](public_uid)}" class="card card-gnl">
 	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${
-          memberFields.firstName
-          } ${memberFields.lastName}</div>
+    memberFields.firstName
+  } ${memberFields.lastName}</div>
 	<div class="card-body card-body-gnl">
 	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${
-          memberFields.currentAddress
-          }</h5>
+    memberFields.currentAddress
+  }</h5>
 	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${
-          memberFields.industry
-          }</h5>
+    memberFields.industry
+  }</h5>
 	<h5 class="card-title"><span class="fas fa-globalnl fa-anchor"></span>${
-          memberFields.hometown
-          }</h5>
+    memberFields.hometown
+  }</h5>
 	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-info-circle"></span>${
-          memberFields.bio
-          }</h5>
+    memberFields.bio
+  }</h5>
   </div>
 </div>
 </div>`;
         console.log(
           "Loaded profile: " +
-          doc.data().first_name +
-          "  -  No LinkedIn  -  " +
-          doc.id
+            doc.data().first_name +
+            "  -  No LinkedIn  -  " +
+            doc.id
         );
       } else {
         memberDomString = `<div class="col-auto p-1 card-col">
 <div id="{[0](public_uid)}" class="card card-gnl">
 	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${
-          memberFields.firstName
-          } ${memberFields.lastName}</div>
+    memberFields.firstName
+  } ${memberFields.lastName}</div>
 	<div class="card-body card-body-gnl">
 	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${
-          memberFields.currentAddress
-          }</h5>
+    memberFields.currentAddress
+  }</h5>
 	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${
-          memberFields.industry
-          }</h5>
+    memberFields.industry
+  }</h5>
 	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-anchor"></span>${
-          memberFields.hometown
-          }</h5>
+    memberFields.hometown
+  }</h5>
   </div>
 </div>
 </div>`;
         console.log(
           "Loaded profile: " +
-          doc.data().first_name +
-          "  -  No LinkedIn  -  " +
-          doc.id
+            doc.data().first_name +
+            "  -  No LinkedIn  -  " +
+            doc.id
         );
       }
       var memObj = $.parseHTML(memberDomString);
@@ -465,7 +465,7 @@ function memberSearch() {
         .where("first_name", "==", formStatic["name"]["first"])
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["name"]["last"]) {
@@ -476,7 +476,7 @@ function memberSearch() {
         .where("last_name", "==", formStatic["name"]["last"])
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["name"]["first"]) {
@@ -488,7 +488,7 @@ function memberSearch() {
         .where("first_name", "==", formStatic["name"]["first"])
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else {
@@ -505,7 +505,7 @@ function memberSearch() {
         .where("first_name", "==", formStatic["name"]["first"])
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["name"]["last"]) {
@@ -515,7 +515,7 @@ function memberSearch() {
         .where("last_name", "==", formStatic["name"]["last"])
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["name"]["first"]) {
@@ -526,7 +526,7 @@ function memberSearch() {
         .where("first_name", "==", formStatic["name"]["first"])
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else {
@@ -554,7 +554,7 @@ function memberSearch() {
         )
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["location"]["prov"]) {
@@ -575,7 +575,7 @@ function memberSearch() {
         )
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["location"]["country"]) {
@@ -591,7 +591,7 @@ function memberSearch() {
         )
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else {
@@ -619,7 +619,7 @@ function memberSearch() {
         .startAfter(last_read_doc)
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["location"]["prov"]) {
@@ -640,7 +640,7 @@ function memberSearch() {
         .startAfter(last_read_doc)
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["location"]["country"]) {
@@ -656,7 +656,7 @@ function memberSearch() {
         .startAfter(last_read_doc)
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else {
@@ -674,7 +674,7 @@ function memberSearch() {
         .where("industry", "==", formStatic["industry"])
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     }
@@ -689,7 +689,7 @@ function memberSearch() {
         .where("industry", "==", formStatic["industry"])
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     }
@@ -718,7 +718,7 @@ function memberSearch() {
         )
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["hometown"]["prov"]) {
@@ -739,7 +739,7 @@ function memberSearch() {
         )
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["hometown"]["country"]) {
@@ -755,7 +755,7 @@ function memberSearch() {
         )
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else {
@@ -787,7 +787,7 @@ function memberSearch() {
         .startAfter(last_read_doc)
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["hometown"]["prov"]) {
@@ -808,7 +808,7 @@ function memberSearch() {
         .startAfter(last_read_doc)
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else if (formStatic["hometown"]["country"]) {
@@ -824,7 +824,7 @@ function memberSearch() {
         .startAfter(last_read_doc)
         .limit(members_per_page)
         .get()
-        .then(function (querySnapshot) {
+        .then(function(querySnapshot) {
           loadMembers(querySnapshot);
         });
     } else {
@@ -837,7 +837,7 @@ function memberSearch() {
       .startAfter(last_read_doc)
       .limit(members_per_page)
       .get()
-      .then(function (querySnapshot) {
+      .then(function(querySnapshot) {
         loadMembers(querySnapshot);
       });
   }
@@ -855,7 +855,7 @@ function getLocationString(locationObject) {
 
     if (
       locationObject.administrative_area_level_1 ==
-      "Newfoundland and Labrador" &&
+        "Newfoundland and Labrador" &&
       locationObject.locality
     ) {
       // Append all required data to array
@@ -911,13 +911,13 @@ function initAutocomplete() {
   // Register our autocomplete elements, see URL for more information
   // https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
   autocomplete_current = new google.maps.places.Autocomplete(
-    /** @type {!HTMLInputElement} */(document.getElementById(
+    /** @type {!HTMLInputElement} */ (document.getElementById(
       "autocomplete_current"
     )),
     { types: ["geocode"] }
   );
   autocomplete_hometown = new google.maps.places.Autocomplete(
-    /** @type {!HTMLInputElement} */(document.getElementById(
+    /** @type {!HTMLInputElement} */ (document.getElementById(
       "autocomplete_hometown"
     )),
     { types: ["geocode"] }
@@ -936,7 +936,7 @@ function initAutocomplete() {
 
   // define event callbacks for each element, these fire when the fields
   // are auto filled by google api and then the location data is stored in our member object
-  autocomplete_current.addListener("place_changed", function () {
+  autocomplete_current.addListener("place_changed", function() {
     try {
       // Get place object from google api
       var place = autocomplete_current.getPlace();
@@ -968,7 +968,7 @@ function initAutocomplete() {
 
   // Second autocomplete callback, the repeated code kills me but im currently lazy
   // TODO: tear out the repeated code into a function above
-  autocomplete_hometown.addListener("place_changed", function () {
+  autocomplete_hometown.addListener("place_changed", function() {
     try {
       // Get place object from google api
       var place = autocomplete_hometown.getPlace();

--- a/public/index.js
+++ b/public/index.js
@@ -1,10 +1,9 @@
 /******************************************************
-* Global variables
-******************************************************/
+ * Global variables
+ ******************************************************/
 
 const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="LIlogin();clickNavBar();return false;" ><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>`;
-			
-			
+
 const loggedinUserBar = `<li class="nav-item" id="linkedin_nav">
 			<a class="nav-link" style="padding:8px 8px 0px 0px;" href="#">
 				<span style="vertical-align:top; margin-top:5px;" class="fab fa-globalnl fa-linkedin-in"></span>
@@ -17,7 +16,6 @@ const loggedinUserBar = `<li class="nav-item" id="linkedin_nav">
 			<li class="nav-item" id="login_name_nav"><a class="nav-link" href="#"><span class="fas fa-globalnl fa-user"></span><span id="login_name"></span></a></li>
 			<li class="nav-item"><a class="nav-link" href="profile.html"><span class="fas fa-globalnl fa-edit"></span><span id="">Edit profile</span></a></li>
 			<li id="button_logout" class="nav-item"><a class="nav-link" href="#"><span class="fas fa-globalnl fa-sign-out-alt"></span><span id="">Logout</span></a></li>`;
-
 
 // Disable LinkedIn banners via toggle button
 var LinkedInEnable = true;
@@ -37,349 +35,472 @@ const members_per_page = 15;
 
 // Track which buttons were pressed to know which pagination query to send when scrolled to bottom of page
 var searchButtonStates = {};
-searchButtonStates['name'] = false;
-searchButtonStates['location'] = false;
-searchButtonStates['industry'] = false;
-searchButtonStates['hometown'] = false;
+searchButtonStates["name"] = false;
+searchButtonStates["location"] = false;
+searchButtonStates["industry"] = false;
+searchButtonStates["hometown"] = false;
 
 // Firebase
-const settings = {timestampsInSnapshots: true};
+const settings = { timestampsInSnapshots: true };
 firebase.firestore().settings(settings);
-var fbi = firebase.firestore().collection('members');
+var fbi = firebase.firestore().collection("members");
 //var uid = firebase.auth().currentUser.uid;
 
-
 firebase.auth().onAuthStateChanged(function(user) {
-  $( "#members-list" ).empty();
+  $("#members-list").empty();
   if (user) {
     // User logged in.
-	$('#userNavBar').html(loggedinUserBar);
-	$("#loginPage").hide();
-	$("#mainPage").show();
-	initLoad();
-	// Load user information at top of page for desktop
-	$('#login_name').html(firebase.auth().currentUser.displayName);
-	$('#linkedin_toggle').change(function() {
-	  if($('#linkedin_toggle:checked').val() == 'on'){
-		  LinkedInEnable = true;
-	  }
-	  else{
-		  LinkedInEnable = false;
-	  }
+    $("#userNavBar").html(loggedinUserBar);
+    $("#loginPage").hide();
+    $("#mainPage").show();
+    initLoad();
+    // Load user information at top of page for desktop
+    $("#login_name").html(firebase.auth().currentUser.displayName);
+    $("#linkedin_toggle").change(function() {
+      if ($("#linkedin_toggle:checked").val() == "on") {
+        LinkedInEnable = true;
+      } else {
+        LinkedInEnable = false;
+      }
+    });
 
-	});
-
-	$('#button_logout').click(function(e){
-		// Cancel the default action
-		e.preventDefault();
-		logout();
-		clickNavBar();
-	});
+    $("#button_logout").click(function(e) {
+      // Cancel the default action
+      e.preventDefault();
+      logout();
+      clickNavBar();
+    });
   } else {
-	$('#userNavBar').html(defaultUserBar);
-	$("#mainPage").hide();
-	$("#loginPage").show();
+    $("#userNavBar").html(defaultUserBar);
+    $("#mainPage").hide();
+    $("#loginPage").show();
   }
 });
 
-function LIlogin(){
-	window.open('login.html','targetWindow','toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=no,width=585,height=600');
+function LIlogin() {
+  window.open(
+    "login.html",
+    "targetWindow",
+    "toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=no,width=585,height=600"
+  );
 }
 
-
-/*****************************************************  
-* Register event callbacks & implement element callbacks
-******************************************************/
+/*****************************************************
+ * Register event callbacks & implement element callbacks
+ ******************************************************/
 // Init auth on load web page event
-$(document).ready(function(){
-	$('#preloader').hide();
-	initApp();
+$(document).ready(function() {
+  $("#preloader").hide();
+  initApp();
 });
 
 // Callback executed on page load
-function initApp(){
+function initApp() {
+  $(window).scroll(function() {
+    if (scrollQueryComplete) {
+      if (
+        $(window).scrollTop() >
+        $(document).height() - $(window).height() - $(window).height() / 6
+      ) {
+        $("#preloader").show();
+        scrollQueryComplete = false;
+        memberSearch();
+      }
+    }
+  });
 
-	$(window).scroll(function() {
-		if(scrollQueryComplete){
-		  if ($(window).scrollTop() > $(document).height() - $(window).height() - $(window).height()/6 ) {
-			$('#preloader').show();
-			scrollQueryComplete=false;
-			memberSearch();
-		}
-	  }
-	});
+  $("#form_name").submit(function(event) {
+    event.preventDefault();
+    if ($("#inputFirstName").val() || $("#inputLastName").val()) {
+      console.log("Searching by name...");
+      $("#members-list").empty();
+      $("#preloader").show();
+      formStatic["name"] = [];
+      formStatic["name"]["first"] =
+        $("#inputFirstName")
+          .val()
+          .charAt(0)
+          .toUpperCase() +
+        $("#inputFirstName")
+          .val()
+          .slice(1)
+          .toLowerCase();
+      formStatic["name"]["last"] =
+        $("#inputLastName")
+          .val()
+          .charAt(0)
+          .toUpperCase() +
+        $("#inputLastName")
+          .val()
+          .slice(1)
+          .toLowerCase();
+      last_read_doc = 0;
+      searchButtonStates["name"] = true;
+      searchButtonStates["location"] = false;
+      searchButtonStates["industry"] = false;
+      searchButtonStates["hometown"] = false;
+      memberSearch();
+    }
+  });
 
-	$('#form_name').submit(function(event){
-		event.preventDefault();
-		if($('#inputFirstName').val() || $('#inputLastName').val()){
-			console.log("Searching by name...");
-			$( "#members-list" ).empty();
-			$('#preloader').show();
-			formStatic['name']=[];
-			formStatic['name']['first'] = $('#inputFirstName').val().charAt(0).toUpperCase() + $('#inputFirstName').val().slice(1).toLowerCase();
-			formStatic['name']['last'] = $('#inputLastName').val().charAt(0).toUpperCase() + $('#inputLastName').val().slice(1).toLowerCase();
-			last_read_doc = 0;
-			searchButtonStates['name']  = true;
-			searchButtonStates['location'] = false;
-			searchButtonStates['industry'] = false;
-			searchButtonStates['hometown'] = false;
-			memberSearch();
-		}
-	});
+  $("#form_location").submit(function(event) {
+    event.preventDefault();
+    if ($("#autocomplete_current").val()) {
+      console.log("Searching by location...");
+      $("#members-list").empty();
+      $("#preloader").show();
+      formStatic["location"] = [];
+      formStatic["location"]["city"] =
+        formDynamic["current_address"]["locality"];
+      formStatic["location"]["prov"] =
+        formDynamic["current_address"]["administrative_area_level_1"];
+      formStatic["location"]["country"] =
+        formDynamic["current_address"]["country"];
+      last_read_doc = 0;
+      searchButtonStates["location"] = true;
+      searchButtonStates["name"] = false;
+      searchButtonStates["industry"] = false;
+      searchButtonStates["hometown"] = false;
+      memberSearch();
+    }
+  });
 
-	$('#form_location').submit(function(event){
-		event.preventDefault();
-		if($('#autocomplete_current').val()){
-			console.log("Searching by location...");
-			$( "#members-list" ).empty();
-			$('#preloader').show();
-			formStatic['location'] = [];
-			formStatic['location']['city'] = formDynamic['current_address']['locality'];
-			formStatic['location']['prov'] = formDynamic['current_address']['administrative_area_level_1'];
-			formStatic['location']['country'] = formDynamic['current_address']['country'];
-			last_read_doc = 0;
-			searchButtonStates['location'] = true;
-			searchButtonStates['name']  = false;
-			searchButtonStates['industry'] = false;
-			searchButtonStates['hometown'] = false;
-			memberSearch();
-		}
-	});
+  $("#form_industry").submit(function(event) {
+    event.preventDefault();
+    if ($("#inputIndustry").val()) {
+      console.log("Searching by industry...");
+      $("#members-list").empty();
+      $("#preloader").show();
+      formStatic["industry"] = $("#inputIndustry").val();
+      last_read_doc = 0;
+      searchButtonStates["industry"] = true;
+      searchButtonStates["name"] = false;
+      searchButtonStates["location"] = false;
+      searchButtonStates["hometown"] = false;
+      memberSearch();
+    }
+  });
 
-	$('#form_industry').submit(function(event){
-		event.preventDefault();
-		if($('#inputIndustry').val()){
-			console.log("Searching by industry...");
-			$( "#members-list" ).empty();
-			$('#preloader').show();
-			formStatic['industry'] = $('#inputIndustry').val();
-			last_read_doc = 0;
-			searchButtonStates['industry'] = true;
-			searchButtonStates['name']  = false;
-			searchButtonStates['location'] = false;
-			searchButtonStates['hometown'] = false;
-			memberSearch();
-		}
-	});
+  $("#form_hometown").submit(function(event) {
+    event.preventDefault();
+    if ($("#autocomplete_hometown").val()) {
+      console.log("Searching by hometown / NL roots...");
+      $("#members-list").empty();
+      $("#preloader").show();
+      formStatic["hometown"] = [];
+      formStatic["hometown"]["city"] =
+        formDynamic["hometown_address"]["locality"];
+      formStatic["hometown"]["prov"] =
+        formDynamic["hometown_address"]["administrative_area_level_1"];
+      formStatic["hometown"]["country"] =
+        formDynamic["hometown_address"]["country"];
+      last_read_doc = 0;
+      searchButtonStates["hometown"] = true;
+      searchButtonStates["name"] = false;
+      searchButtonStates["location"] = false;
+      searchButtonStates["industry"] = false;
+      memberSearch();
+    }
+  });
 
-	$('#form_hometown').submit(function(event){
-		event.preventDefault();
-		if($('#autocomplete_hometown').val()){
-			console.log("Searching by hometown / NL roots...");
-			$( "#members-list" ).empty();
-			$('#preloader').show();
-			formStatic['hometown'] = [];
-			formStatic['hometown']['city'] = formDynamic['hometown_address']['locality'];
-			formStatic['hometown']['prov'] = formDynamic['hometown_address']['administrative_area_level_1'];
-			formStatic['hometown']['country'] = formDynamic['hometown_address']['country'];
-			last_read_doc = 0;
-			searchButtonStates['hometown'] = true;
-			searchButtonStates['name']  = false;
-			searchButtonStates['location'] = false;
-			searchButtonStates['industry'] = false;
-			memberSearch();
-		}
-	});
+  $(".clear_button").click(function(event) {
+    console.log("Clear search...");
+    $("#preloader").show();
+    $("#form_name")
+      .get(0)
+      .reset();
+    $("#form_location")
+      .get(0)
+      .reset();
+    $("#form_industry")
+      .get(0)
+      .reset();
+    $("#form_hometown")
+      .get(0)
+      .reset();
+    searchButtonStates["name"] = false;
+    searchButtonStates["location"] = false;
+    searchButtonStates["industry"] = false;
+    searchButtonStates["hometown"] = false;
+    last_read_doc = 0;
+    $("#members-list").empty();
+    memberSearch();
+  });
 
-	$('.clear_button').click(function(event){
-		console.log("Clear search...");
-		$('#preloader').show();
-		$('#form_name').get(0).reset();
-		$('#form_location').get(0).reset();
-		$('#form_industry').get(0).reset();
-		$('#form_hometown').get(0).reset();
-		searchButtonStates['name']  = false;
-		searchButtonStates['location'] = false;
-		searchButtonStates['industry'] = false;
-		searchButtonStates['hometown'] = false;
-		last_read_doc = 0;
-		$( "#members-list" ).empty();
-		memberSearch();
-	});
-		
-    return true;
+  return true;
 }
 //end initApp
 // Callback executed on page load
-function initLoad(){
-	var memberDocRef = fbi.doc(firebase.auth().currentUser.uid);
+function initLoad() {
+  var memberDocRef = fbi.doc(firebase.auth().currentUser.uid);
 
-	var getMemberDoc = memberDocRef.get()
+  var getMemberDoc = memberDocRef
+    .get()
     .then(doc => {
       if (!doc.exists) {
-        console.log('User does not exist in database');
-		logout();
+        console.log("User does not exist in database");
+        logout();
       } else {
-		
-		if(!doc.data().date_updated || doc.data().date_updated == "-1"){
-			window.location.href = "profile.html";
-		}
-		formDynamic["current_address"] = doc.data().current_address;
-		formDynamic["hometown_address"] = doc.data().hometown_address;
-		
-		formStatic['hometown'] = [];		
-		formStatic['hometown']['city'] = formDynamic['hometown_address']['locality'] || "";
-		formStatic['hometown']['prov'] = formDynamic['hometown_address']['administrative_area_level_1'] || "";
-		formStatic['hometown']['country'] = formDynamic['hometown_address']['country'] || "";
-		
-		formStatic['location'] = [];
-		formStatic['location']['city'] = formDynamic['current_address']['locality'] || "";
-		formStatic['location']['prov'] = formDynamic['current_address']['administrative_area_level_1'] || "";
-		formStatic['location']['country'] = formDynamic['current_address']['country'] || "";
-		
-		if(formDynamic["current_address"] != null){
-			if(formDynamic["current_address"]["form_address"] != null) 
-				$("#autocomplete_current").val( formDynamic["current_address"]["form_address"] );
-			else
-				$("#autocomplete_current").val( getLocationString(formDynamic["current_address"]) );
-		}
-		if(formDynamic["hometown_address"] != null){
-			if(formDynamic["hometown_address"]["form_address"] != null)
-				$("#autocomplete_hometown").val( formDynamic["hometown_address"]["form_address"] );
-			else
-				$("#autocomplete_hometown").val( getLocationString(formDynamic["hometown_address"]) );
-		}
-		
+        if (!doc.data().date_updated || doc.data().date_updated == "-1") {
+          window.location.href = "profile.html";
+        }
+        formDynamic["current_address"] = doc.data().current_address;
+        formDynamic["hometown_address"] = doc.data().hometown_address;
+
+        formStatic["hometown"] = [];
+        formStatic["hometown"]["city"] =
+          formDynamic["hometown_address"]["locality"] || "";
+        formStatic["hometown"]["prov"] =
+          formDynamic["hometown_address"]["administrative_area_level_1"] || "";
+        formStatic["hometown"]["country"] =
+          formDynamic["hometown_address"]["country"] || "";
+
+        formStatic["location"] = [];
+        formStatic["location"]["city"] =
+          formDynamic["current_address"]["locality"] || "";
+        formStatic["location"]["prov"] =
+          formDynamic["current_address"]["administrative_area_level_1"] || "";
+        formStatic["location"]["country"] =
+          formDynamic["current_address"]["country"] || "";
+
+        if (formDynamic["current_address"] != null) {
+          if (formDynamic["current_address"]["form_address"] != null)
+            $("#autocomplete_current").val(
+              formDynamic["current_address"]["form_address"]
+            );
+          else
+            $("#autocomplete_current").val(
+              getLocationString(formDynamic["current_address"])
+            );
+        }
+        if (formDynamic["hometown_address"] != null) {
+          if (formDynamic["hometown_address"]["form_address"] != null)
+            $("#autocomplete_hometown").val(
+              formDynamic["hometown_address"]["form_address"]
+            );
+          else
+            $("#autocomplete_hometown").val(
+              getLocationString(formDynamic["hometown_address"])
+            );
+        }
       }
     })
     .catch(err => {
-      console.log('Error getting document', err);
+      console.log("Error getting document", err);
     });
-	
-	fbi.orderBy("last_name").where("copied_account", "==", false).startAt('A').limit(members_per_page)
-	.get().then(function(querySnapshot) {
-		loadMembers(querySnapshot);
-	});
 
-    return true;
+  fbi
+    .orderBy("last_name")
+    .where("copied_account", "==", false)
+    .startAt("A")
+    .limit(members_per_page)
+    .get()
+    .then(function(querySnapshot) {
+      loadMembers(querySnapshot);
+    });
+
+  return true;
 }
 
 // profile load callback
 function profile() {
-    console.log("Nav profile.html");
-    window.location.href = "profile.html";
+  console.log("Nav profile.html");
+  window.location.href = "profile.html";
 }
 
 // Logout callback
 function logout() {
-    firebase.auth().signOut().then(function() {
-        console.log('Signed Out');
+  firebase
+    .auth()
+    .signOut()
+    .then(
+      function() {
+        console.log("Signed Out");
         //window.location.href = "index.html";
-    }, function(error) {
-        console.error('Sign Out Error', error);
-    });
+      },
+      function(error) {
+        console.error("Sign Out Error", error);
+      }
+    );
 }
 
-function clickNavBar(){
-	if($('.navbar-toggler').css('display') !='none'){
-		$('.navbar-toggler').trigger( "click" );
-	}
+function clickNavBar() {
+  if ($(".navbar-toggler").css("display") != "none") {
+    $(".navbar-toggler").trigger("click");
+  }
 }
-
 
 /* load members
 */
-function loadMembers(querySnapshot){
-	if(querySnapshot.docs.length > 0){
-		last_read_doc = querySnapshot.docs[querySnapshot.docs.length - 1];
-		querySnapshot.forEach(function(doc) {
-			// doc.data() is never undefined for query doc snapshots
-			
-			// copied_account set if old account migrated over - need to manually delete these
-			//if(!doc.data().copied_account){	
-				// Build argument's for memberElement
-				var memberFields = {
-					public_uid : doc.id,
-					firstName : doc.data().first_name,
-					lastName : doc.data().last_name,
-					currentAddress : getLocationString(doc.data().current_address),
-					industry : doc.data().industry,
-					hometown : getLocationString(doc.data().hometown_address),
-					bio: doc.data().bio || "",
-					linkedin_profile : doc.data().linkedin_profile
-				}
-			
-				// Build element and inject
-				var memberDomString;
-				if(doc.data().linkedin_profile && doc.data().linkedin_profile.length > 30 && LinkedInEnable && memberFields.bio){
-				memberDomString = `<div class="col-auto p-1 card-col">
+function loadMembers(querySnapshot) {
+  if (querySnapshot.docs.length > 0) {
+    last_read_doc = querySnapshot.docs[querySnapshot.docs.length - 1];
+    querySnapshot.forEach(function(doc) {
+      // doc.data() is never undefined for query doc snapshots
+
+      // copied_account set if old account migrated over - need to manually delete these
+      //if(!doc.data().copied_account){
+      // Build argument's for memberElement
+      var memberFields = {
+        public_uid: doc.id,
+        firstName: doc.data().first_name,
+        lastName: doc.data().last_name,
+        currentAddress: getLocationString(doc.data().current_address),
+        industry: doc.data().industry,
+        hometown: getLocationString(doc.data().hometown_address),
+        bio: doc.data().bio || "",
+        linkedin_profile: doc.data().linkedin_profile
+      };
+
+      // Build element and inject
+      var memberDomString;
+      if (
+        doc.data().linkedin_profile &&
+        doc.data().linkedin_profile.length > 30 &&
+        LinkedInEnable &&
+        memberFields.bio
+      ) {
+        memberDomString = `<div class="col-auto p-1 card-col">
 <div id="${memberFields.public_uid}" class="card card-gnl">
-	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${memberFields.firstName} ${memberFields.lastName}</div>
+	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${
+    memberFields.firstName
+  } ${memberFields.lastName}</div>
 	<div class="card-body card-body-gnl">
-	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${memberFields.currentAddress}</h5>
-	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${memberFields.industry}</h5>
-	<h5 class="card-title"><span class="fas fa-globalnl fa-anchor"></span>${memberFields.hometown}</h5>
-	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-info-circle"></span>${memberFields.bio}</h5>
+	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${
+    memberFields.currentAddress
+  }</h5>
+	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${
+    memberFields.industry
+  }</h5>
+	<h5 class="card-title"><span class="fas fa-globalnl fa-anchor"></span>${
+    memberFields.hometown
+  }</h5>
+	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-info-circle"></span>${
+    memberFields.bio
+  }</h5>
 	<div class="linkedin_profile_card">
-	<script type="IN/MemberProfile" data-id="${memberFields.linkedin_profile}" data-format="inline" data-related="false"></script>
+	<script type="IN/MemberProfile" data-id="${
+    memberFields.linkedin_profile
+  }" data-format="inline" data-related="false"></script>
 	</div>
-  </div>
-</div>
-</div>`;	
-				console.log("Loaded profile: " + doc.data().first_name + "  -  " + doc.data().linkedin_profile + "  -  " + doc.id);	
-				}
-				else if(doc.data().linkedin_profile && doc.data().linkedin_profile.length > 30 && LinkedInEnable){
-				memberDomString = `<div class="col-auto p-1 card-col">
-<div id="${memberFields.public_uid}" class="card card-gnl">
-	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${memberFields.firstName} ${memberFields.lastName}</div>
-	<div class="card-body card-body-gnl">
-	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${memberFields.currentAddress}</h5>
-	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${memberFields.industry}</h5>
-	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-anchor"></span>${memberFields.hometown}</h5>
-	<div class="linkedin_profile_card">
-	<script type="IN/MemberProfile" data-id="${memberFields.linkedin_profile}" data-format="inline" data-related="false"></script>
-	</div>
-  </div>
-</div>
-</div>`;	
-				console.log("Loaded profile: " + doc.data().first_name + "  -  " + doc.data().linkedin_profile + "  -  " + doc.id);	
-				}
-				else if(memberFields.bio){
-				memberDomString = `<div class="col-auto p-1 card-col">
-<div id="{[0](public_uid)}" class="card card-gnl">
-	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${memberFields.firstName} ${memberFields.lastName}</div>
-	<div class="card-body card-body-gnl">
-	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${memberFields.currentAddress}</h5>
-	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${memberFields.industry}</h5>
-	<h5 class="card-title"><span class="fas fa-globalnl fa-anchor"></span>${memberFields.hometown}</h5>
-	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-info-circle"></span>${memberFields.bio}</h5>
   </div>
 </div>
 </div>`;
-				console.log("Loaded profile: " + doc.data().first_name + "  -  No LinkedIn  -  " + doc.id);
-				}
-				else{
-				memberDomString = `<div class="col-auto p-1 card-col">
-<div id="{[0](public_uid)}" class="card card-gnl">
-	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${memberFields.firstName} ${memberFields.lastName}</div>
+        console.log(
+          "Loaded profile: " +
+            doc.data().first_name +
+            "  -  " +
+            doc.data().linkedin_profile +
+            "  -  " +
+            doc.id
+        );
+      } else if (
+        doc.data().linkedin_profile &&
+        doc.data().linkedin_profile.length > 30 &&
+        LinkedInEnable
+      ) {
+        memberDomString = `<div class="col-auto p-1 card-col">
+<div id="${memberFields.public_uid}" class="card card-gnl">
+	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${
+    memberFields.firstName
+  } ${memberFields.lastName}</div>
 	<div class="card-body card-body-gnl">
-	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${memberFields.currentAddress}</h5>
-	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${memberFields.industry}</h5>
-	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-anchor"></span>${memberFields.hometown}</h5>
+	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${
+    memberFields.currentAddress
+  }</h5>
+	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${
+    memberFields.industry
+  }</h5>
+	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-anchor"></span>${
+    memberFields.hometown
+  }</h5>
+	<div class="linkedin_profile_card">
+	<script type="IN/MemberProfile" data-id="${
+    memberFields.linkedin_profile
+  }" data-format="inline" data-related="false"></script>
+	</div>
   </div>
 </div>
-</div>`;	
-				console.log("Loaded profile: " + doc.data().first_name + "  -  No LinkedIn  -  " + doc.id);
-				}
-				var memObj = $.parseHTML(memberDomString);
-				$( "#members-list" ).append(memObj);
-			//}
-			//else{
-			//	console.log("Duplicate profile: " + doc.data().first_name + "  -  " + doc.id);
-			//}
-			});
-		
-			if(LinkedInEnable){
-				IN.parse();
-				console.log('Parse LinkedIn badges...');
-			}
-			if(querySnapshot.docs.length === 15)
-				scrollQueryComplete=true;
-		}
-	else{
-			last_read_doc = 0;
-	}
-	$('#preloader').hide();
+</div>`;
+        console.log(
+          "Loaded profile: " +
+            doc.data().first_name +
+            "  -  " +
+            doc.data().linkedin_profile +
+            "  -  " +
+            doc.id
+        );
+      } else if (memberFields.bio) {
+        memberDomString = `<div class="col-auto p-1 card-col">
+<div id="{[0](public_uid)}" class="card card-gnl">
+	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${
+    memberFields.firstName
+  } ${memberFields.lastName}</div>
+	<div class="card-body card-body-gnl">
+	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${
+    memberFields.currentAddress
+  }</h5>
+	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${
+    memberFields.industry
+  }</h5>
+	<h5 class="card-title"><span class="fas fa-globalnl fa-anchor"></span>${
+    memberFields.hometown
+  }</h5>
+	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-info-circle"></span>${
+    memberFields.bio
+  }</h5>
+  </div>
+</div>
+</div>`;
+        console.log(
+          "Loaded profile: " +
+            doc.data().first_name +
+            "  -  No LinkedIn  -  " +
+            doc.id
+        );
+      } else {
+        memberDomString = `<div class="col-auto p-1 card-col">
+<div id="{[0](public_uid)}" class="card card-gnl">
+	<div class="card-header card-header-gnl"><span class="fas fa-gnl-head fa-portrait"></span>${
+    memberFields.firstName
+  } ${memberFields.lastName}</div>
+	<div class="card-body card-body-gnl">
+	<h5 class="card-title"><span class="fas fa-globalnl fa-map-marker-alt"></span>${
+    memberFields.currentAddress
+  }</h5>
+	<h5 class="card-title"><span class="fas fa-globalnl fa-briefcase"></span>${
+    memberFields.industry
+  }</h5>
+	<h5 class="card-title card-title-bottom"><span class="fas fa-globalnl fa-anchor"></span>${
+    memberFields.hometown
+  }</h5>
+  </div>
+</div>
+</div>`;
+        console.log(
+          "Loaded profile: " +
+            doc.data().first_name +
+            "  -  No LinkedIn  -  " +
+            doc.id
+        );
+      }
+      var memObj = $.parseHTML(memberDomString);
+      $("#members-list").append(memObj);
+      //}
+      //else{
+      //	console.log("Duplicate profile: " + doc.data().first_name + "  -  " + doc.id);
+      //}
+    });
+
+    if (LinkedInEnable) {
+      IN.parse();
+      console.log("Parse LinkedIn badges...");
+    }
+    if (querySnapshot.docs.length === 15) scrollQueryComplete = true;
+  } else {
+    last_read_doc = 0;
+  }
+  $("#preloader").hide();
 } // end loadMembers
 
 /* Searching
@@ -388,212 +509,395 @@ function loadMembers(querySnapshot){
 
 */
 
-function memberSearch(){
-	if(searchButtonStates['name']  && last_read_doc){
-		if(formStatic['name'] == null){
-			alert('Please enter a name to search');
-		}
-		else if(formStatic['name']['first'] && formStatic['name']['last']){
-			console.log('First name and last name entered');
-			fbi.startAfter(last_read_doc).where("copied_account", "==", false).where("last_name", "==", formStatic['name']['last']).where("first_name", "==", formStatic['name']['first']).limit(members_per_page)
-				.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else if(formStatic['name']['last']){
-			console.log('Last name only entered');
-			fbi.startAfter(last_read_doc).where("copied_account", "==", false).where("last_name", "==", formStatic['name']['last']).limit(members_per_page)
-				.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else if(formStatic['name']['first']){
-			console.log('First name only entered');
-			fbi.orderBy('last_name').startAfter(last_read_doc).where("copied_account", "==", false).where("first_name", "==", formStatic['name']['first']).limit(members_per_page)
-				.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else{
-			console.log('Error');
-		}
-	}
-	else if(searchButtonStates['name'] ){
-		if(formStatic['name'] == null){
-			alert('Please enter a name to search');
-		}
-		else if(formStatic['name']['first'] && formStatic['name']['last']){
-			console.log('First name and last name entered');
-			fbi.where("copied_account", "==", false).where("last_name", "==", formStatic['name']['last']).where("first_name", "==", formStatic['name']['first']).limit(members_per_page)
-				.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else if(formStatic['name']['last']){
-			console.log('Last name only entered');
-			fbi.where("copied_account", "==", false).where("last_name", "==", formStatic['name']['last']).limit(members_per_page)
-				.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else if(formStatic['name']['first']){
-			console.log('First name only entered');
-			fbi.orderBy('last_name').where("copied_account", "==", false).where("first_name", "==", formStatic['name']['first']).limit(members_per_page)
-				.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else{
-			console.log('Error');
-		}
-	}
-	else if(searchButtonStates['location'] && last_read_doc){
-		if(formStatic['location'] == null){
-			alert('Please enter a Current Location');
-		}
-		else if(formStatic['location']['city']){
-			console.log('Town entered');
-			fbi.orderBy('last_name').startAfter(last_read_doc).where("copied_account", "==", false).where("current_address.locality", "==", formStatic['location']['city']).where("current_address.administrative_area_level_1", "==", formStatic['location']['prov']).where("current_address.country", "==", formStatic['location']['country']).limit(members_per_page)
-			.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else if(formStatic['location']['prov']){
-			console.log('Province/State entered');
-			fbi.orderBy('last_name').startAfter(last_read_doc).where("copied_account", "==", false).where("current_address.administrative_area_level_1", "==", formStatic['location']['prov']).where("current_address.country", "==", formStatic['location']['country']).limit(members_per_page)
-			.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else if(formStatic['location']['country']){
-			console.log('Country entered');
-			fbi.orderBy('last_name').startAfter(last_read_doc).where("copied_account", "==", false).where("current_address.country", "==", formStatic['location']['country']).limit(members_per_page)
-			.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else{
-			console.log('Error');
-		}
-	}
-	else if(searchButtonStates['location']){
-		if(formStatic['location'] == null){
-			alert('Please enter a Current Location 2');
-		}
-		else if(formStatic['location']['city']){
-			console.log('Town entered');
-			fbi.orderBy('last_name').where("copied_account", "==", false).where("current_address.locality", "==", formStatic['location']['city']).where("current_address.administrative_area_level_1", "==", formStatic['location']['prov']).where("current_address.country", "==", formStatic['location']['country']).startAfter(last_read_doc).limit(members_per_page)
-			.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else if(formStatic['location']['prov']){
-			console.log('Province/State entered');
-			fbi.orderBy('last_name').where("copied_account", "==", false).where("current_address.administrative_area_level_1", "==", formStatic['location']['prov']).where("current_address.country", "==", formStatic['location']['country']).startAfter(last_read_doc).limit(members_per_page)
-			.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else if(formStatic['location']['country']){
-			console.log('Country entered');
-			fbi.orderBy('last_name').where("copied_account", "==", false).where("current_address.country", "==", formStatic['location']['country']).startAfter(last_read_doc).limit(members_per_page)
-			.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else{
-			console.log('Error');
-		}
-	}
-	else if(searchButtonStates['industry'] && last_read_doc){
-		if(formStatic['industry'] == null){
-			alert('Please enter an industry to search');
-		}
-		else{
-			console.log('Industry entered');
-			fbi.orderBy('last_name').startAfter(last_read_doc).where("copied_account", "==", false).where("industry", "==", formStatic['industry']).limit(members_per_page)
-			.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-
-	}
-	else if(searchButtonStates['industry']){
-		if(formStatic['industry'] == null){
-			alert('Please enter an industry to search');
-		}
-		else{
-			console.log('Industry entered');
-			fbi.orderBy('last_name').where("copied_account", "==", false).where("industry", "==", formStatic['industry']).limit(members_per_page)
-			.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-	}
-	else if(searchButtonStates['hometown'] && last_read_doc){
-		if(formDynamic['hometown_address'] == null){
-			alert('Please enter a location');
-		}
-		else if(formStatic['hometown']['city']){
-			console.log('Town entered');
-			fbi.orderBy('last_name').startAfter(last_read_doc).where("hometown_address.locality", "==", formStatic['hometown']['city']).where("hometown_address.administrative_area_level_1", "==", formStatic['hometown']['prov']).where("hometown_address.country", "==", formStatic['hometown']['country']).limit(members_per_page)
-			.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else if(formStatic['hometown']['prov']){
-			console.log('Province/State entered');
-			fbi.orderBy('last_name').startAfter(last_read_doc).where("copied_account", "==", false).where("hometown_address.administrative_area_level_1", "==", formStatic['hometown']['prov']).where("hometown_address.country", "==", formStatic['hometown']['country']).limit(members_per_page)
-			.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else if(formStatic['hometown']['country']){
-			console.log('Country entered');
-			fbi.orderBy('last_name').startAfter(last_read_doc).where("copied_account", "==", false).where("hometown_address.country", "==", formStatic['hometown']['country']).limit(members_per_page)
-			.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else{
-			console.log('Error');
-		}
-	}
-	else if(searchButtonStates['hometown']){
-		if(formStatic['hometown'] == null){
-			alert('Please enter a location');
-		}
-		else if(formStatic['hometown']['city']){
-			console.log('Town entered');
-			fbi.orderBy('last_name').where("copied_account", "==", false).where("hometown_address.locality", "==", formStatic['hometown']['city']).where("hometown_address.administrative_area_level_1", "==", formStatic['hometown']['prov']).where("hometown_address.country", "==", formStatic['hometown']['country']).startAfter(last_read_doc).limit(members_per_page)
-			.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else if(formStatic['hometown']['prov']){
-			console.log('Province/State entered');
-			fbi.orderBy('last_name').where("copied_account", "==", false).where("hometown_address.administrative_area_level_1", "==", formStatic['hometown']['prov']).where("hometown_address.country", "==", formStatic['hometown']['country']).startAfter(last_read_doc).limit(members_per_page)
-			.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else if(formStatic['hometown']['country']){
-			console.log('Country entered');
-			fbi.orderBy('last_name').where("copied_account", "==", false).where("hometown_address.country", "==", formStatic['hometown']['country']).startAfter(last_read_doc).limit(members_per_page)
-			.get().then(function(querySnapshot) {
-				loadMembers(querySnapshot);
-			});
-		}
-		else{
-			console.log('Error');
-		}
-	}
-	else{
-		fbi.orderBy("last_name").where("copied_account", "==", false).startAfter(last_read_doc).limit(members_per_page)
-		.get().then(function(querySnapshot) {
-			loadMembers(querySnapshot);
-		});
-	}
+function memberSearch() {
+  if (searchButtonStates["name"] && last_read_doc) {
+    if (formStatic["name"] == null) {
+      alert("Please enter a name to search");
+    } else if (formStatic["name"]["first"] && formStatic["name"]["last"]) {
+      console.log("First name and last name entered");
+      fbi
+        .startAfter(last_read_doc)
+        .where("copied_account", "==", false)
+        .where("last_name", "==", formStatic["name"]["last"])
+        .where("first_name", "==", formStatic["name"]["first"])
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else if (formStatic["name"]["last"]) {
+      console.log("Last name only entered");
+      fbi
+        .startAfter(last_read_doc)
+        .where("copied_account", "==", false)
+        .where("last_name", "==", formStatic["name"]["last"])
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else if (formStatic["name"]["first"]) {
+      console.log("First name only entered");
+      fbi
+        .orderBy("last_name")
+        .startAfter(last_read_doc)
+        .where("copied_account", "==", false)
+        .where("first_name", "==", formStatic["name"]["first"])
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else {
+      console.log("Error");
+    }
+  } else if (searchButtonStates["name"]) {
+    if (formStatic["name"] == null) {
+      alert("Please enter a name to search");
+    } else if (formStatic["name"]["first"] && formStatic["name"]["last"]) {
+      console.log("First name and last name entered");
+      fbi
+        .where("copied_account", "==", false)
+        .where("last_name", "==", formStatic["name"]["last"])
+        .where("first_name", "==", formStatic["name"]["first"])
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else if (formStatic["name"]["last"]) {
+      console.log("Last name only entered");
+      fbi
+        .where("copied_account", "==", false)
+        .where("last_name", "==", formStatic["name"]["last"])
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else if (formStatic["name"]["first"]) {
+      console.log("First name only entered");
+      fbi
+        .orderBy("last_name")
+        .where("copied_account", "==", false)
+        .where("first_name", "==", formStatic["name"]["first"])
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else {
+      console.log("Error");
+    }
+  } else if (searchButtonStates["location"] && last_read_doc) {
+    if (formStatic["location"] == null) {
+      alert("Please enter a Current Location");
+    } else if (formStatic["location"]["city"]) {
+      console.log("Town entered");
+      fbi
+        .orderBy("last_name")
+        .startAfter(last_read_doc)
+        .where("copied_account", "==", false)
+        .where("current_address.locality", "==", formStatic["location"]["city"])
+        .where(
+          "current_address.administrative_area_level_1",
+          "==",
+          formStatic["location"]["prov"]
+        )
+        .where(
+          "current_address.country",
+          "==",
+          formStatic["location"]["country"]
+        )
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else if (formStatic["location"]["prov"]) {
+      console.log("Province/State entered");
+      fbi
+        .orderBy("last_name")
+        .startAfter(last_read_doc)
+        .where("copied_account", "==", false)
+        .where(
+          "current_address.administrative_area_level_1",
+          "==",
+          formStatic["location"]["prov"]
+        )
+        .where(
+          "current_address.country",
+          "==",
+          formStatic["location"]["country"]
+        )
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else if (formStatic["location"]["country"]) {
+      console.log("Country entered");
+      fbi
+        .orderBy("last_name")
+        .startAfter(last_read_doc)
+        .where("copied_account", "==", false)
+        .where(
+          "current_address.country",
+          "==",
+          formStatic["location"]["country"]
+        )
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else {
+      console.log("Error");
+    }
+  } else if (searchButtonStates["location"]) {
+    if (formStatic["location"] == null) {
+      alert("Please enter a Current Location 2");
+    } else if (formStatic["location"]["city"]) {
+      console.log("Town entered");
+      fbi
+        .orderBy("last_name")
+        .where("copied_account", "==", false)
+        .where("current_address.locality", "==", formStatic["location"]["city"])
+        .where(
+          "current_address.administrative_area_level_1",
+          "==",
+          formStatic["location"]["prov"]
+        )
+        .where(
+          "current_address.country",
+          "==",
+          formStatic["location"]["country"]
+        )
+        .startAfter(last_read_doc)
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else if (formStatic["location"]["prov"]) {
+      console.log("Province/State entered");
+      fbi
+        .orderBy("last_name")
+        .where("copied_account", "==", false)
+        .where(
+          "current_address.administrative_area_level_1",
+          "==",
+          formStatic["location"]["prov"]
+        )
+        .where(
+          "current_address.country",
+          "==",
+          formStatic["location"]["country"]
+        )
+        .startAfter(last_read_doc)
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else if (formStatic["location"]["country"]) {
+      console.log("Country entered");
+      fbi
+        .orderBy("last_name")
+        .where("copied_account", "==", false)
+        .where(
+          "current_address.country",
+          "==",
+          formStatic["location"]["country"]
+        )
+        .startAfter(last_read_doc)
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else {
+      console.log("Error");
+    }
+  } else if (searchButtonStates["industry"] && last_read_doc) {
+    if (formStatic["industry"] == null) {
+      alert("Please enter an industry to search");
+    } else {
+      console.log("Industry entered");
+      fbi
+        .orderBy("last_name")
+        .startAfter(last_read_doc)
+        .where("copied_account", "==", false)
+        .where("industry", "==", formStatic["industry"])
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    }
+  } else if (searchButtonStates["industry"]) {
+    if (formStatic["industry"] == null) {
+      alert("Please enter an industry to search");
+    } else {
+      console.log("Industry entered");
+      fbi
+        .orderBy("last_name")
+        .where("copied_account", "==", false)
+        .where("industry", "==", formStatic["industry"])
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    }
+  } else if (searchButtonStates["hometown"] && last_read_doc) {
+    if (formDynamic["hometown_address"] == null) {
+      alert("Please enter a location");
+    } else if (formStatic["hometown"]["city"]) {
+      console.log("Town entered");
+      fbi
+        .orderBy("last_name")
+        .startAfter(last_read_doc)
+        .where(
+          "hometown_address.locality",
+          "==",
+          formStatic["hometown"]["city"]
+        )
+        .where(
+          "hometown_address.administrative_area_level_1",
+          "==",
+          formStatic["hometown"]["prov"]
+        )
+        .where(
+          "hometown_address.country",
+          "==",
+          formStatic["hometown"]["country"]
+        )
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else if (formStatic["hometown"]["prov"]) {
+      console.log("Province/State entered");
+      fbi
+        .orderBy("last_name")
+        .startAfter(last_read_doc)
+        .where("copied_account", "==", false)
+        .where(
+          "hometown_address.administrative_area_level_1",
+          "==",
+          formStatic["hometown"]["prov"]
+        )
+        .where(
+          "hometown_address.country",
+          "==",
+          formStatic["hometown"]["country"]
+        )
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else if (formStatic["hometown"]["country"]) {
+      console.log("Country entered");
+      fbi
+        .orderBy("last_name")
+        .startAfter(last_read_doc)
+        .where("copied_account", "==", false)
+        .where(
+          "hometown_address.country",
+          "==",
+          formStatic["hometown"]["country"]
+        )
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else {
+      console.log("Error");
+    }
+  } else if (searchButtonStates["hometown"]) {
+    if (formStatic["hometown"] == null) {
+      alert("Please enter a location");
+    } else if (formStatic["hometown"]["city"]) {
+      console.log("Town entered");
+      fbi
+        .orderBy("last_name")
+        .where("copied_account", "==", false)
+        .where(
+          "hometown_address.locality",
+          "==",
+          formStatic["hometown"]["city"]
+        )
+        .where(
+          "hometown_address.administrative_area_level_1",
+          "==",
+          formStatic["hometown"]["prov"]
+        )
+        .where(
+          "hometown_address.country",
+          "==",
+          formStatic["hometown"]["country"]
+        )
+        .startAfter(last_read_doc)
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else if (formStatic["hometown"]["prov"]) {
+      console.log("Province/State entered");
+      fbi
+        .orderBy("last_name")
+        .where("copied_account", "==", false)
+        .where(
+          "hometown_address.administrative_area_level_1",
+          "==",
+          formStatic["hometown"]["prov"]
+        )
+        .where(
+          "hometown_address.country",
+          "==",
+          formStatic["hometown"]["country"]
+        )
+        .startAfter(last_read_doc)
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else if (formStatic["hometown"]["country"]) {
+      console.log("Country entered");
+      fbi
+        .orderBy("last_name")
+        .where("copied_account", "==", false)
+        .where(
+          "hometown_address.country",
+          "==",
+          formStatic["hometown"]["country"]
+        )
+        .startAfter(last_read_doc)
+        .limit(members_per_page)
+        .get()
+        .then(function(querySnapshot) {
+          loadMembers(querySnapshot);
+        });
+    } else {
+      console.log("Error");
+    }
+  } else {
+    fbi
+      .orderBy("last_name")
+      .where("copied_account", "==", false)
+      .startAfter(last_read_doc)
+      .limit(members_per_page)
+      .get()
+      .then(function(querySnapshot) {
+        loadMembers(querySnapshot);
+      });
+  }
 }
 
 /* Build location string
@@ -601,50 +905,62 @@ function memberSearch(){
     into a formatted string
     @param locationObject (Object{}) - value from location field (Either past or current) from firebase
 */
-function getLocationString(locationObject)
-{
-	if(locationObject){
+function getLocationString(locationObject) {
+  if (locationObject) {
     // Initalize empty array to work with
     var location = [];
 
-	if(locationObject.administrative_area_level_1 == "Newfoundland and Labrador" && locationObject.locality){
-		// Append all required data to array
-		location.push(locationObject.locality);
-	}
-	else if(locationObject.administrative_area_level_1 == "Newfoundland and Labrador"){
-		// Append all required data to array
-		location.push("Newfoundland and Labrador");
-	}
-	else if(locationObject.country == "Canada" || locationObject.country == "United States"){ 
-		if(!locationObject.locality && locationObject.administrative_area_level_1){
-			location.push(locationObject.administrative_area_level_1);
-		}
-		else if(!locationObject.administrative_area_level_1){
-			location.push(locationObject.country);
-		}
-		else{
-			location.push(locationObject.locality, locationObject.administrative_area_level_1);
-		}
-	}
-	else if(!locationObject.locality){
-		if(!locationObject.administrative_area_level_1){
-			location.push(locationObject.country);
-		}
-		else{
-			location.push(locationObject.administrative_area_level_1, locationObject.country);
-		}
-	}
-	else{
-		location.push(locationObject.locality, locationObject.administrative_area_level_1, locationObject.country);
-	}
-	// Filter array for unwanted data, then join with ', ' to create a comma separated string from data
-	return location.filter(e => e !== "" && e !== undefined).join(", "); 
-	}
-	else{
-		return '';
-	}
+    if (
+      locationObject.administrative_area_level_1 ==
+        "Newfoundland and Labrador" &&
+      locationObject.locality
+    ) {
+      // Append all required data to array
+      location.push(locationObject.locality);
+    } else if (
+      locationObject.administrative_area_level_1 == "Newfoundland and Labrador"
+    ) {
+      // Append all required data to array
+      location.push("Newfoundland and Labrador");
+    } else if (
+      locationObject.country == "Canada" ||
+      locationObject.country == "United States"
+    ) {
+      if (
+        !locationObject.locality &&
+        locationObject.administrative_area_level_1
+      ) {
+        location.push(locationObject.administrative_area_level_1);
+      } else if (!locationObject.administrative_area_level_1) {
+        location.push(locationObject.country);
+      } else {
+        location.push(
+          locationObject.locality,
+          locationObject.administrative_area_level_1
+        );
+      }
+    } else if (!locationObject.locality) {
+      if (!locationObject.administrative_area_level_1) {
+        location.push(locationObject.country);
+      } else {
+        location.push(
+          locationObject.administrative_area_level_1,
+          locationObject.country
+        );
+      }
+    } else {
+      location.push(
+        locationObject.locality,
+        locationObject.administrative_area_level_1,
+        locationObject.country
+      );
+    }
+    // Filter array for unwanted data, then join with ', ' to create a comma separated string from data
+    return location.filter(e => e !== "" && e !== undefined).join(", ");
+  } else {
+    return "";
+  }
 }
-
 
 // Callback for google maps autocomplete for storing autocompleted location data into
 // the new member objcet
@@ -652,83 +968,91 @@ function initAutocomplete() {
   // Register our autocomplete elements, see URL for more information
   // https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
   autocomplete_current = new google.maps.places.Autocomplete(
-      /** @type {!HTMLInputElement} */(document.getElementById('autocomplete_current')),
-      {types: ['geocode']});
+    /** @type {!HTMLInputElement} */ (document.getElementById(
+      "autocomplete_current"
+    )),
+    { types: ["geocode"] }
+  );
   autocomplete_hometown = new google.maps.places.Autocomplete(
-      /** @type {!HTMLInputElement} */(document.getElementById('autocomplete_hometown')),
-      {types: ['geocode']});
+    /** @type {!HTMLInputElement} */ (document.getElementById(
+      "autocomplete_hometown"
+    )),
+    { types: ["geocode"] }
+  );
 
   // Look for these keys in the place object returned by google API
   // if found, their values are filled and written to our new member object
   var locationData = {
-      street_number               : true,
-      route                       : true,
-      locality                    : true,
-      administrative_area_level_1 : true,
-      country                     : true,
-      postal_code                 : true
+    street_number: true,
+    route: true,
+    locality: true,
+    administrative_area_level_1: true,
+    country: true,
+    postal_code: true
   };
 
   // define event callbacks for each element, these fire when the fields
-    // are auto filled by google api and then the location data is stored in our member object
-    autocomplete_current.addListener('place_changed', function(){
-      try{
-          // Get place object from google api
-          var place = autocomplete_current.getPlace();
-          if(place){
-              // iterate over object and look for the keys in locationData
-              formDynamic["current_address"] = {
-				administrative_area_level_1 : null,  
-				country: null,  
-				lat: null,  
-				lng: null,
-				locality: null
-			  };
-              for (var i = 0; i < place.address_components.length; i++) {
-                  var addressType = place.address_components[i].types[0];
-                  if (locationData.hasOwnProperty(addressType)) {
-                      formDynamic["current_address"][addressType] = place.address_components[i]["long_name"];;
-                  }
-              }
-              // Store geometry into new member object as well
-              formDynamic["current_address"]["lat"] = place.geometry.location.lat();
-              formDynamic["current_address"]["lng"] = place.geometry.location.lng();
-			  //console.log(formDynamic);
+  // are auto filled by google api and then the location data is stored in our member object
+  autocomplete_current.addListener("place_changed", function() {
+    try {
+      // Get place object from google api
+      var place = autocomplete_current.getPlace();
+      if (place) {
+        // iterate over object and look for the keys in locationData
+        formDynamic["current_address"] = {
+          administrative_area_level_1: null,
+          country: null,
+          lat: null,
+          lng: null,
+          locality: null
+        };
+        for (var i = 0; i < place.address_components.length; i++) {
+          var addressType = place.address_components[i].types[0];
+          if (locationData.hasOwnProperty(addressType)) {
+            formDynamic["current_address"][addressType] =
+              place.address_components[i]["long_name"];
           }
-      }catch(err){
-          console.log(err);
+        }
+        // Store geometry into new member object as well
+        formDynamic["current_address"]["lat"] = place.geometry.location.lat();
+        formDynamic["current_address"]["lng"] = place.geometry.location.lng();
+        //console.log(formDynamic);
       }
+    } catch (err) {
+      console.log(err);
+    }
   });
 
   // Second autocomplete callback, the repeated code kills me but im currently lazy
   // TODO: tear out the repeated code into a function above
-  autocomplete_hometown.addListener('place_changed', function() {
-      try{
-          // Get place object from google api
-          var place = autocomplete_hometown.getPlace();
-          if(place){
-              // iterate over object and look for the keys in locationData
-              formDynamic["hometown_address"] = {
-				administrative_area_level_1 : null,  
-				country: null,  
-				lat: null,  
-				lng: null,
-				locality: null
-			  };
+  autocomplete_hometown.addListener("place_changed", function() {
+    try {
+      // Get place object from google api
+      var place = autocomplete_hometown.getPlace();
+      if (place) {
+        // iterate over object and look for the keys in locationData
+        formDynamic["hometown_address"] = {
+          administrative_area_level_1: null,
+          country: null,
+          lat: null,
+          lng: null,
+          locality: null
+        };
 
-              for (var i = 0; i < place.address_components.length; i++) {
-              var addressType = place.address_components[i].types[0];
-                  if (locationData.hasOwnProperty(addressType) ){
-                      formDynamic["hometown_address"][addressType] = place.address_components[i]["long_name"];;
-                  }
-              }
-              // Store geometry into new member object as well
-              formDynamic["hometown_address"]["lat"] = place.geometry.location.lat();
-              formDynamic["hometown_address"]["lng"] = place.geometry.location.lng();
-			  //console.log(formDynamic);
+        for (var i = 0; i < place.address_components.length; i++) {
+          var addressType = place.address_components[i].types[0];
+          if (locationData.hasOwnProperty(addressType)) {
+            formDynamic["hometown_address"][addressType] =
+              place.address_components[i]["long_name"];
           }
-      }catch(err){
-          console.log(err);
+        }
+        // Store geometry into new member object as well
+        formDynamic["hometown_address"]["lat"] = place.geometry.location.lat();
+        formDynamic["hometown_address"]["lng"] = place.geometry.location.lng();
+        //console.log(formDynamic);
       }
+    } catch (err) {
+      console.log(err);
+    }
   });
 }

--- a/public/map.html
+++ b/public/map.html
@@ -72,7 +72,7 @@
             </li>
           </ul>
 		  <ul id="userNavBar" class="nav navbar-nav navbar-right">
-			<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();clickNavBar();return false;"><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>
+			<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();gnl.navBar.toggle();return false;"><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>
 		</ul>
 	
       </nav>

--- a/public/map.html
+++ b/public/map.html
@@ -72,7 +72,7 @@
             </li>
           </ul>
 		  <ul id="userNavBar" class="nav navbar-nav navbar-right">
-			<li class="nav-item"><a class="nav-link" href="#" onClick="LIlogin();clickNavBar();return false;"><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>
+			<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();clickNavBar();return false;"><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>
 		</ul>
 	
       </nav>
@@ -91,7 +91,7 @@
 			   to continue to the Global NL Members Portal
 			  </p>  
 			  </div>
-			  <img class="mx-auto d-block" alt="Sign in with LinkedIn" id="sign-in-button" onClick="LIlogin();return false;" 
+			  <img class="mx-auto d-block" alt="Sign in with LinkedIn" id="sign-in-button" onClick="gnl.auth.loginLinkedIn();return false;" 
 			  src="assets/Sign-In-Small---Default.png" onmouseover="this.src='assets/Sign-In-Small---Hover.png'" onmouseout="this.src='assets/Sign-In-Small---Default.png'"/>
         <div class="w-100 m-2"></div>
       <div id="loginPage_text" class="text-center">
@@ -128,6 +128,7 @@
 	<!-- <script src="//platform.linkedin.com/in.js" type="text/javascript"></script> -->
 	
 	<!-- Site source, handlers and interfaces first, then the page code -->
+	<script type="text/javascript" src="gnl.js"></script>
 	<script type="text/javascript" src="map.js"></script>
 	 
 	 <!-- auto complete from google maps must be called after map.js -->

--- a/public/map.js
+++ b/public/map.js
@@ -71,7 +71,7 @@ function initMap() {
       $("#button_logout").click(function(e) {
         // Cancel the default action
         e.preventDefault();
-        logout();
+        gnl.auth.logout();
         clickNavBar();
       });
       parseCords();
@@ -166,21 +166,6 @@ function loadMembersOnMap(ne, sw) {
 function profile() {
   console.log("Nav profile.html");
   window.location.href = "profile.html";
-}
-
-// Logout callback
-function logout() {
-  firebase
-    .auth()
-    .signOut()
-    .then(
-      function() {
-        console.log("Signed Out");
-      },
-      function(error) {
-        console.error("Sign Out Error", error);
-      }
-    );
 }
 
 function clickNavBar() {

--- a/public/map.js
+++ b/public/map.js
@@ -7,7 +7,7 @@ var oms;
 var infowindow;
 var members = [];
 
-const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="LIlogin();clickNavBar();return false;" ><span class="fas fa-globalnl fa-user"></span><span">Sign in</span></a></li>`;
+const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();clickNavBar();return false;" ><span class="fas fa-globalnl fa-user"></span><span">Sign in</span></a></li>`;
 
 const loggedinUserBar = `<li class="nav-item" id="login_name_nav"><a class="nav-link" href="#"><span class="fas fa-globalnl fa-user"></span><span id="login_name"></span></a></li>
 			<li class="nav-item"><a class="nav-link" href="profile.html"><span class="fas fa-globalnl fa-edit"></span><span id="">Edit profile</span></a></li>
@@ -166,14 +166,6 @@ function loadMembersOnMap(ne, sw) {
 function profile() {
   console.log("Nav profile.html");
   window.location.href = "profile.html";
-}
-
-function LIlogin() {
-  window.open(
-    "login.html",
-    "targetWindow",
-    "toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=no,width=585,height=600"
-  );
 }
 
 // Logout callback

--- a/public/map.js
+++ b/public/map.js
@@ -7,7 +7,7 @@ var oms;
 var infowindow;
 var members = [];
 
-const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();clickNavBar();return false;" ><span class="fas fa-globalnl fa-user"></span><span">Sign in</span></a></li>`;
+const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();gnl.navBar.toggle();return false;" ><span class="fas fa-globalnl fa-user"></span><span">Sign in</span></a></li>`;
 
 const loggedinUserBar = `<li class="nav-item" id="login_name_nav"><a class="nav-link" href="#"><span class="fas fa-globalnl fa-user"></span><span id="login_name"></span></a></li>
 			<li class="nav-item"><a class="nav-link" href="profile.html"><span class="fas fa-globalnl fa-edit"></span><span id="">Edit profile</span></a></li>
@@ -72,7 +72,7 @@ function initMap() {
         // Cancel the default action
         e.preventDefault();
         gnl.auth.logout();
-        clickNavBar();
+        gnl.navBar.toggle();
       });
       parseCords();
     } else {
@@ -166,10 +166,4 @@ function loadMembersOnMap(ne, sw) {
 function profile() {
   console.log("Nav profile.html");
   window.location.href = "profile.html";
-}
-
-function clickNavBar() {
-  if ($(".navbar-toggler").css("display") != "none") {
-    $(".navbar-toggler").trigger("click");
-  }
 }

--- a/public/map.js
+++ b/public/map.js
@@ -1,6 +1,6 @@
 /******************************************************
-* Global variables
-******************************************************/
+ * Global variables
+ ******************************************************/
 
 var _map;
 var oms;
@@ -13,161 +13,186 @@ const loggedinUserBar = `<li class="nav-item" id="login_name_nav"><a class="nav-
 			<li class="nav-item"><a class="nav-link" href="profile.html"><span class="fas fa-globalnl fa-edit"></span><span id="">Edit profile</span></a></li>
 			<li id="button_logout" class="nav-item"><a class="nav-link" href="#"><span class="fas fa-globalnl fa-sign-out-alt"></span><span id="">Logout</span></a></li>`;
 
-/*****************************************************  
-* Firestore
-******************************************************/
+/*****************************************************
+ * Firestore
+ ******************************************************/
 
-const settings = {timestampsInSnapshots: true};
+const settings = { timestampsInSnapshots: true };
 firebase.firestore().settings(settings);
-var fbi = firebase.firestore().collection('members');
+var fbi = firebase.firestore().collection("members");
 var uid;
 var memberDocRef;
 
-
-
-/*****************************************************  
-* Register event callbacks & implement element callbacks
-******************************************************/
+/*****************************************************
+ * Register event callbacks & implement element callbacks
+ ******************************************************/
 // Init auth on load web page event
-$(document).ready(function(){
-});
+$(document).ready(function() {});
 
 // Callback executed on page load
 function initMap() {
-	firebase.auth().onAuthStateChanged(function(user) {
-  $( "#members-list" ).empty();
-  if (user) {
-    // User logged in.
-	$('#userNavBar').html(loggedinUserBar);
-	$("#loginPage").hide();
-	
-	if(!infowindow){
-		infowindow = new google.maps.InfoWindow();
-		// Try HTML5 geolocation.
-		if (navigator.geolocation) {
-		  navigator.geolocation.getCurrentPosition(function(position) {
-			initMap2({
-			  lat: position.coords.latitude,
-			  lng: position.coords.longitude
-			});
-		  }, function() {
-			// location service error
-			initmap2({lat: 41.9380, lng: -76.091697});
-		  });
-		}else{
-			initmap2({lat: 41.9380, lng: -76.091697});
-		}
-	}
-	
-	
-	$("#map").show();
-	uid = firebase.auth().currentUser.uid;
-	memberDocRef = firebase.firestore().collection('members').doc(uid);
-	// Load user information at top of page for desktop
-	$('#login_name').html(firebase.auth().currentUser.displayName);
-	$('#display_name').val(firebase.auth().currentUser.displayName);
-	$('#button_logout').click(function(e){
-		// Cancel the default action
-		e.preventDefault();
-		logout();
-		clickNavBar();
-	});
-	parseCords();
-  } else {
-	$('#userNavBar').html(defaultUserBar);
-	$("#map").hide();
-	$("#loginPage").show();
-  }
-});
+  firebase.auth().onAuthStateChanged(function(user) {
+    $("#members-list").empty();
+    if (user) {
+      // User logged in.
+      $("#userNavBar").html(loggedinUserBar);
+      $("#loginPage").hide();
+
+      if (!infowindow) {
+        infowindow = new google.maps.InfoWindow();
+        // Try HTML5 geolocation.
+        if (navigator.geolocation) {
+          navigator.geolocation.getCurrentPosition(
+            function(position) {
+              initMap2({
+                lat: position.coords.latitude,
+                lng: position.coords.longitude
+              });
+            },
+            function() {
+              // location service error
+              initmap2({ lat: 41.938, lng: -76.091697 });
+            }
+          );
+        } else {
+          initmap2({ lat: 41.938, lng: -76.091697 });
+        }
+      }
+
+      $("#map").show();
+      uid = firebase.auth().currentUser.uid;
+      memberDocRef = firebase
+        .firestore()
+        .collection("members")
+        .doc(uid);
+      // Load user information at top of page for desktop
+      $("#login_name").html(firebase.auth().currentUser.displayName);
+      $("#display_name").val(firebase.auth().currentUser.displayName);
+      $("#button_logout").click(function(e) {
+        // Cancel the default action
+        e.preventDefault();
+        logout();
+        clickNavBar();
+      });
+      parseCords();
+    } else {
+      $("#userNavBar").html(defaultUserBar);
+      $("#map").hide();
+      $("#loginPage").show();
+    }
+  });
 }
 //end initMap
 
-function initMap2(homepos){
-	_map = new google.maps.Map(document.getElementById('map'), {
-      zoom: 7,
-      center: homepos,
-	  streetViewControl: false
-    });
-	oms = new OverlappingMarkerSpiderfier(_map, {
-		markersWontMove: true,
-		markersWontHide: true,
-		keepSpiderfied: true,
-		basicFormatEvents: true
-	});
-    google.maps.event.addListener(_map, 'bounds_changed', function(ev){
-        parseCords();
-    });
+function initMap2(homepos) {
+  _map = new google.maps.Map(document.getElementById("map"), {
+    zoom: 7,
+    center: homepos,
+    streetViewControl: false
+  });
+  oms = new OverlappingMarkerSpiderfier(_map, {
+    markersWontMove: true,
+    markersWontHide: true,
+    keepSpiderfied: true,
+    basicFormatEvents: true
+  });
+  google.maps.event.addListener(_map, "bounds_changed", function(ev) {
+    parseCords();
+  });
 }
 
-function parseCords(){
-	if(_map && uid){
-		var bounds = _map.getBounds();
-		var ne = bounds.getNorthEast(); // LatLng of the north-east corner
-		var sw = bounds.getSouthWest(); // LatLng of the south-west corder
-		var neCorner = {"lat" : ne.lat(), "lng" : ne.lng()};
-		var swCorner = {"lat" : sw.lat(), "lng" : sw.lng()};
-		loadMembersOnMap(neCorner,swCorner);
-	}
+function parseCords() {
+  if (_map && uid) {
+    var bounds = _map.getBounds();
+    var ne = bounds.getNorthEast(); // LatLng of the north-east corner
+    var sw = bounds.getSouthWest(); // LatLng of the south-west corder
+    var neCorner = { lat: ne.lat(), lng: ne.lng() };
+    var swCorner = { lat: sw.lat(), lng: sw.lng() };
+    loadMembersOnMap(neCorner, swCorner);
+  }
 }
-
 
 // Queries database for all members currently located within the coordinates
 // and creates a pin on the map for each member
-function loadMembersOnMap(ne,sw){
-    // Oddly enough, you can't filter over different fields... so we take whatever is
-    // between the latitude lines and filter out the longitude locally
-    fbi.where("copied_account", "==", false).where("current_address.lat" , "<", ne.lat).where("current_address.lat", ">", sw.lat)
-    .get().then( function(result){
-        result.forEach( function(doc){
-			if(!members.includes(doc.id) && doc.data().current_address.lat){
-				memberData = doc.data();
-				var memLoc = {lat:memberData.current_address.lat, lng:memberData.current_address.lng};
-				var name = memberData.first_name+" "+memberData.last_name;
-				if( memLoc.lng < ne.lng && memLoc.lng > sw.lng  ){
-					members.push(doc.id);
-					let currentTown = (memberData.current_address) ? (memberData.current_address.locality || "") : "";
-					let homeTown = (memberData.hometown_address) ? (memberData.hometown_address.locality || "") : "";
-					var contentString = `<span class="fas fa-gnl-map fa-portrait"></span><b>${memberData.first_name} ${memberData.last_name}</b><br/>
+function loadMembersOnMap(ne, sw) {
+  // Oddly enough, you can't filter over different fields... so we take whatever is
+  // between the latitude lines and filter out the longitude locally
+  fbi
+    .where("copied_account", "==", false)
+    .where("current_address.lat", "<", ne.lat)
+    .where("current_address.lat", ">", sw.lat)
+    .get()
+    .then(function(result) {
+      result.forEach(function(doc) {
+        if (!members.includes(doc.id) && doc.data().current_address.lat) {
+          memberData = doc.data();
+          var memLoc = {
+            lat: memberData.current_address.lat,
+            lng: memberData.current_address.lng
+          };
+          var name = memberData.first_name + " " + memberData.last_name;
+          if (memLoc.lng < ne.lng && memLoc.lng > sw.lng) {
+            members.push(doc.id);
+            let currentTown = memberData.current_address
+              ? memberData.current_address.locality || ""
+              : "";
+            let homeTown = memberData.hometown_address
+              ? memberData.hometown_address.locality || ""
+              : "";
+            var contentString = `<span class="fas fa-gnl-map fa-portrait"></span><b>${
+              memberData.first_name
+            } ${memberData.last_name}</b><br/>
 <span class="fas fa-gnl-map fa-map-marker-alt"></span>${currentTown}<br/>					
 <span class="fas fa-gnl-map fa-briefcase"></span>${memberData.industry}<br/>
 <span class="fas fa-gnl-map fa-anchor"></span>${homeTown}`;
-					var marker = new google.maps.Marker({
-						position : memLoc,
-						title: name,
-						text: contentString
-					})
-					google.maps.event.addListener(marker, 'spider_click', function(e) {  // 'spider_click', not plain 'click'
-						infowindow.setContent(marker.text);
-						infowindow.open(_map, marker);
-					});
-					oms.addMarker(marker);  // adds the marker to the spiderfier _and_ the map
-				}
-			}
-		}		)
-    })
+            var marker = new google.maps.Marker({
+              position: memLoc,
+              title: name,
+              text: contentString
+            });
+            google.maps.event.addListener(marker, "spider_click", function(e) {
+              // 'spider_click', not plain 'click'
+              infowindow.setContent(marker.text);
+              infowindow.open(_map, marker);
+            });
+            oms.addMarker(marker); // adds the marker to the spiderfier _and_ the map
+          }
+        }
+      });
+    });
 }
 
 // profile load callback
 function profile() {
-    console.log("Nav profile.html");
-    window.location.href = "profile.html";
+  console.log("Nav profile.html");
+  window.location.href = "profile.html";
 }
 
-function LIlogin(){
-	window.open('login.html','targetWindow','toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=no,width=585,height=600');
+function LIlogin() {
+  window.open(
+    "login.html",
+    "targetWindow",
+    "toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=no,width=585,height=600"
+  );
 }
 
 // Logout callback
 function logout() {
-    firebase.auth().signOut().then(function() {
-        console.log('Signed Out');
-    }, function(error) {
-        console.error('Sign Out Error', error);
-    });
+  firebase
+    .auth()
+    .signOut()
+    .then(
+      function() {
+        console.log("Signed Out");
+      },
+      function(error) {
+        console.error("Sign Out Error", error);
+      }
+    );
 }
 
-function clickNavBar(){
-	if($('.navbar-toggler').css('display') !='none'){
-		$('.navbar-toggler').trigger( "click" );
-	}
+function clickNavBar() {
+  if ($(".navbar-toggler").css("display") != "none") {
+    $(".navbar-toggler").trigger("click");
+  }
 }

--- a/public/map.js
+++ b/public/map.js
@@ -21,7 +21,7 @@ var memberDocRef;
  * Register event callbacks & implement element callbacks
  ******************************************************/
 // Init auth on load web page event
-$(document).ready(function () { });
+$(document).ready(function() {});
 
 function renderWithUser(user) {
   if (!infowindow) {
@@ -29,13 +29,13 @@ function renderWithUser(user) {
     // Try HTML5 geolocation.
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
-        function (position) {
+        function(position) {
           initMap2({
             lat: position.coords.latitude,
             lng: position.coords.longitude
           });
         },
-        function () {
+        function() {
           // location service error
           initMap2({ lat: 41.938, lng: -76.091697 });
         }
@@ -53,7 +53,7 @@ function renderWithUser(user) {
     .doc(uid);
   // Load user information at top of page for desktop
   $("#login_name").html(user.displayName);
-  $("#button_logout").click(function (e) {
+  $("#button_logout").click(function(e) {
     // Cancel the default action
     e.preventDefault();
     gnl.auth.logout();
@@ -83,7 +83,7 @@ function initMap2(homepos) {
     keepSpiderfied: true,
     basicFormatEvents: true
   });
-  google.maps.event.addListener(_map, "bounds_changed", function (ev) {
+  google.maps.event.addListener(_map, "bounds_changed", function(ev) {
     parseCords();
   });
 }
@@ -109,8 +109,8 @@ function loadMembersOnMap(ne, sw) {
     .where("current_address.lat", "<", ne.lat)
     .where("current_address.lat", ">", sw.lat)
     .get()
-    .then(function (result) {
-      result.forEach(function (doc) {
+    .then(function(result) {
+      result.forEach(function(doc) {
         if (!members.includes(doc.id) && doc.data().current_address.lat) {
           memberData = doc.data();
           var memLoc = {
@@ -128,7 +128,7 @@ function loadMembersOnMap(ne, sw) {
               : "";
             var contentString = `<span class="fas fa-gnl-map fa-portrait"></span><b>${
               memberData.first_name
-              } ${memberData.last_name}</b><br/>
+            } ${memberData.last_name}</b><br/>
 <span class="fas fa-gnl-map fa-map-marker-alt"></span>${currentTown}<br/>					
 <span class="fas fa-gnl-map fa-briefcase"></span>${memberData.industry}<br/>
 <span class="fas fa-gnl-map fa-anchor"></span>${homeTown}`;
@@ -137,7 +137,7 @@ function loadMembersOnMap(ne, sw) {
               title: name,
               text: contentString
             });
-            google.maps.event.addListener(marker, "spider_click", function (e) {
+            google.maps.event.addListener(marker, "spider_click", function(e) {
               // 'spider_click', not plain 'click'
               infowindow.setContent(marker.text);
               infowindow.open(_map, marker);

--- a/public/map.js
+++ b/public/map.js
@@ -7,12 +7,6 @@ var oms;
 var infowindow;
 var members = [];
 
-const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();gnl.navBar.toggle();return false;" ><span class="fas fa-globalnl fa-user"></span><span">Sign in</span></a></li>`;
-
-const loggedinUserBar = `<li class="nav-item" id="login_name_nav"><a class="nav-link" href="#"><span class="fas fa-globalnl fa-user"></span><span id="login_name"></span></a></li>
-			<li class="nav-item"><a class="nav-link" href="profile.html"><span class="fas fa-globalnl fa-edit"></span><span id="">Edit profile</span></a></li>
-			<li id="button_logout" class="nav-item"><a class="nav-link" href="#"><span class="fas fa-globalnl fa-sign-out-alt"></span><span id="">Logout</span></a></li>`;
-
 /*****************************************************
  * Firestore
  ******************************************************/
@@ -43,11 +37,11 @@ function renderWithUser(user) {
         },
         function () {
           // location service error
-          initmap2({ lat: 41.938, lng: -76.091697 });
+          initMap2({ lat: 41.938, lng: -76.091697 });
         }
       );
     } else {
-      initmap2({ lat: 41.938, lng: -76.091697 });
+      initMap2({ lat: 41.938, lng: -76.091697 });
     }
   }
 
@@ -74,7 +68,7 @@ function renderWithoutUser() {
 
 // Callback executed on page load
 function initMap() {
-  gnl.auth.listenForStageChange(renderWithUser, renderWithoutUser);
+  gnl.auth.listenForStageChange(renderWithUser, renderWithoutUser, false);
 }
 
 function initMap2(homepos) {

--- a/public/profile.html
+++ b/public/profile.html
@@ -65,7 +65,7 @@
             </li>
           </ul>
 		  <ul id="userNavBar" class="nav navbar-nav navbar-right">
-			<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();clickNavBar();return false;"><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>
+			<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();gnl.navBar.toggle();return false;"><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>
 		</ul>
 	
       </nav>

--- a/public/profile.html
+++ b/public/profile.html
@@ -65,7 +65,7 @@
             </li>
           </ul>
 		  <ul id="userNavBar" class="nav navbar-nav navbar-right">
-			<li class="nav-item"><a class="nav-link" href="#" onClick="LIlogin();clickNavBar();return false;"><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>
+			<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();clickNavBar();return false;"><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>
 		</ul>
 	
       </nav>
@@ -81,7 +81,7 @@
 			   to continue to the Global NL Members Portal
 			  </p>  
 			  </div>
-			  <img class="mx-auto d-block" alt="Sign in with LinkedIn" id="sign-in-button" onClick="LIlogin();return false;" 
+			  <img class="mx-auto d-block" alt="Sign in with LinkedIn" id="sign-in-button" onClick="gnl.auth.loginLinkedIn();return false;" 
 			  src="assets/Sign-In-Small---Default.png" onmouseover="this.src='assets/Sign-In-Small---Hover.png'" onmouseout="this.src='assets/Sign-In-Small---Default.png'"/>
         <div class="w-100 m-2"></div>
       <div id="loginPage_text" class="text-center">
@@ -290,6 +290,7 @@
 	<script src="/__/firebase/5.3.0/firebase-firestore.js"></script>
 	<script src="/__/firebase/init.js"></script>
 
+	<script type="text/javascript" src="gnl.js"></script>
 	<script src="profile.js"></script>
 
 

--- a/public/profile.js
+++ b/public/profile.js
@@ -8,7 +8,7 @@ var privateDocRef;
 // For storing current location and hometown from Google Maps
 var locationArray = {};
 
-const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();clickNavBar();return false;" ><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>`;
+const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();gnl.navBar.toggle();return false;" ><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>`;
 
 const loggedinUserBar = `<li class="nav-item" id="login_name_nav"><a class="nav-link" href="#"><span class="fas fa-globalnl fa-user"></span><span id="login_name"></span></a></li>
 			<li class="nav-item"><a class="nav-link" href="profile.html"><span class="fas fa-globalnl fa-edit"></span><span id="">Edit profile</span></a></li>
@@ -50,7 +50,7 @@ firebase.auth().onAuthStateChanged(function(user) {
       // Cancel the default action
       e.preventDefault();
       gnl.auth.logout();
-      clickNavBar();
+      gnl.navBar.toggle();
     });
     initApp();
   } else {
@@ -59,12 +59,6 @@ firebase.auth().onAuthStateChanged(function(user) {
     $("#loginPage").show();
   }
 });
-
-function clickNavBar() {
-  if ($(".navbar-toggler").css("display") != "none") {
-    $(".navbar-toggler").trigger("click");
-  }
-}
 
 // Prevent the enter key from submitting the form when uncomplete
 $(window).keydown(function(event) {

--- a/public/profile.js
+++ b/public/profile.js
@@ -25,50 +25,38 @@ firebase.firestore().settings(settings);
  * Register event callbacks & implement element callbacks
  ******************************************************/
 // Start execution when page is done loading
-$(document).ready(function() {});
+$(document).ready(function () { });
 
-firebase.auth().onAuthStateChanged(function(user) {
-  $("#members-list").empty();
-  if (user) {
-    // User logged in.
-    $("#loginPage").hide();
-    $("#mainPage").show();
-    $("#userNavBar").html(loggedinUserBar);
-    uid = firebase.auth().currentUser.uid;
-    memberDocRef = firebase
-      .firestore()
-      .collection("members")
-      .doc(uid);
-    privateDocRef = firebase
-      .firestore()
-      .collection("private_data")
-      .doc(uid);
-    // Load user information at top of page for desktop
-    $("#login_name").html(firebase.auth().currentUser.displayName);
-    $("#display_name").val(firebase.auth().currentUser.displayName);
-    $("#button_logout").click(function(e) {
-      // Cancel the default action
-      e.preventDefault();
-      gnl.auth.logout();
-      gnl.navBar.toggle();
-    });
-    initApp();
-  } else {
-    $("#userNavBar").html(defaultUserBar);
-    $("#mainPage").hide();
-    $("#loginPage").show();
-  }
-});
+function renderWithUser(user) {
+  $("#mainPage").show();
+  uid = user.uid;
+  memberDocRef = firebase
+    .firestore()
+    .collection("members")
+    .doc(uid);
+  privateDocRef = firebase
+    .firestore()
+    .collection("private_data")
+    .doc(uid);
+  $("#display_name").val(user.displayName);
+  initApp();
+}
+
+function renderWithoutUser() {
+  $("#mainPage").hide();
+}
+
+gnl.auth.listenForStageChange(renderWithUser, renderWithoutUser);
 
 // Prevent the enter key from submitting the form when uncomplete
-$(window).keydown(function(event) {
+$(window).keydown(function (event) {
   if (event.keyCode == 13) {
     event.preventDefault();
     return false;
   }
 });
 // MUN grad change event
-$("#MUN").on("change", function() {
+$("#MUN").on("change", function () {
   if ($(this).val() === "Yes") {
     $("#grad_year").show();
   } else {
@@ -89,13 +77,13 @@ function initAutocomplete() {
   // Register our autocomplete elements, see URL for more information
   // https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
   autocomplete_current = new google.maps.places.Autocomplete(
-    /** @type {!HTMLInputElement} */ (document.getElementById(
+    /** @type {!HTMLInputElement} */(document.getElementById(
       "autocomplete_current"
     )),
     { types: ["geocode"] }
   );
   autocomplete_hometown = new google.maps.places.Autocomplete(
-    /** @type {!HTMLInputElement} */ (document.getElementById(
+    /** @type {!HTMLInputElement} */(document.getElementById(
       "autocomplete_hometown"
     )),
     { types: ["geocode"] }
@@ -114,7 +102,7 @@ function initAutocomplete() {
 
   // define event callbacks for each element, these fire when the fields
   // are auto filled by google api and then the location data is stored in our member object
-  autocomplete_current.addListener("place_changed", function() {
+  autocomplete_current.addListener("place_changed", function () {
     try {
       // Get place object from google api
       var place = autocomplete_current.getPlace();
@@ -154,7 +142,7 @@ function initAutocomplete() {
 
   // Second autocomplete callback, the repeated code kills me but im currently lazy
   // TODO: tear out the repeated code into a function above
-  autocomplete_hometown.addListener("place_changed", function() {
+  autocomplete_hometown.addListener("place_changed", function () {
     try {
       // Get place object from google api
       var place = autocomplete_hometown.getPlace();
@@ -198,13 +186,13 @@ function initAutocomplete() {
   });
 }
 
-$("#cancelButton").click(function() {
+$("#cancelButton").click(function () {
   event.preventDefault();
   window.location.replace("index.html");
 });
 
 // form submit callback
-$("#profile_form").submit(function(event) {
+$("#profile_form").submit(function (event) {
   // prevent navigation out of page
   event.preventDefault();
   /* Store known fields into member objcet
@@ -256,20 +244,20 @@ $("#profile_form").submit(function(event) {
 
   const memberDatabaseTask = memberDocRef
     .set(member, { merge: true })
-    .then(function() {
+    .then(function () {
       console.log("Successfully wrote to public database");
     })
-    .catch(function(error) {
+    .catch(function (error) {
       console.log(error);
       console.log("Error writing public database properties for ", uid);
     });
 
   const privateDatabaseTask = privateDocRef
     .set(private_data, { merge: true })
-    .then(function() {
+    .then(function () {
       console.log("Successfully wrote to private database");
     })
-    .catch(function(error) {
+    .catch(function (error) {
       console.log(error);
       console.log("Error writing private database properties for ", uid);
     });

--- a/public/profile.js
+++ b/public/profile.js
@@ -68,116 +68,22 @@ function changeMUN() {
 // Callback for google maps autocomplete for storing autocompleted location data into
 // the new member objcet
 function initAutocomplete() {
-  // Register our autocomplete elements, see URL for more information
-  // https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
-  autocomplete_current = new google.maps.places.Autocomplete(
-    /** @type {!HTMLInputElement} */ (document.getElementById(
-      "autocomplete_current"
-    )),
-    { types: ["geocode"] }
-  );
-  autocomplete_hometown = new google.maps.places.Autocomplete(
-    /** @type {!HTMLInputElement} */ (document.getElementById(
-      "autocomplete_hometown"
-    )),
-    { types: ["geocode"] }
-  );
-
-  // Look for these keys in the place object returned by google API
-  // if found, their values are filled and written to our new member object
-  var locationData = {
-    street_number: true,
-    route: true,
-    locality: true,
-    administrative_area_level_1: true,
-    country: true,
-    postal_code: true
-  };
-
-  // define event callbacks for each element, these fire when the fields
-  // are auto filled by google api and then the location data is stored in our member object
-  autocomplete_current.addListener("place_changed", function() {
-    try {
-      // Get place object from google api
-      var place = autocomplete_current.getPlace();
-      if (place) {
-        // iterate over object and look for the keys in locationData
-        locationArray["current_address"] = {
-          locality: null,
-          administrative_area_level_1: null,
-          country: null,
-          locality_short: null,
-          administrative_area_level_1_short: null,
-          country_short: null,
-          postal_code: null,
-          lat: null,
-          lng: null
-        };
-        for (var i = 0; i < place.address_components.length; i++) {
-          var addressType = place.address_components[i].types[0];
-          if (locationData.hasOwnProperty(addressType)) {
-            locationArray["current_address"][addressType] =
-              place.address_components[i]["long_name"];
-            locationArray["current_address"][addressType + "_short"] =
-              place.address_components[i]["short_name"];
-          }
-        }
-        // Store geometry into new member object as well
-        locationArray["current_address"]["lat"] = place.geometry.location.lat();
-        locationArray["current_address"]["lng"] = place.geometry.location.lng();
-        locationArray["current_address"]["form_address"] = $(
-          "#autocomplete_current"
-        ).val();
-      }
-    } catch (err) {
-      console.log(err);
+  gnl.location.bindAutocomplete(
+    locationArray,
+    "autocomplete_current",
+    "current_address",
+    function currentAddress() {
+      $("#autocomplete_current").val();
     }
-  });
-
-  // Second autocomplete callback, the repeated code kills me but im currently lazy
-  // TODO: tear out the repeated code into a function above
-  autocomplete_hometown.addListener("place_changed", function() {
-    try {
-      // Get place object from google api
-      var place = autocomplete_hometown.getPlace();
-      if (place) {
-        // iterate over object and look for the keys in locationData
-        locationArray["hometown_address"] = {
-          locality: null,
-          administrative_area_level_1: null,
-          country: null,
-          locality_short: null,
-          administrative_area_level_1_short: null,
-          country_short: null,
-          postal_code: null,
-          lat: null,
-          lng: null
-        };
-
-        for (var i = 0; i < place.address_components.length; i++) {
-          var addressType = place.address_components[i].types[0];
-          if (locationData.hasOwnProperty(addressType)) {
-            locationArray["hometown_address"][addressType] =
-              place.address_components[i]["long_name"];
-            locationArray["hometown_address"][addressType + "_short"] =
-              place.address_components[i]["short_name"];
-          }
-        }
-        // Store geometry into new member object as well
-        locationArray["hometown_address"][
-          "lat"
-        ] = place.geometry.location.lat();
-        locationArray["hometown_address"][
-          "lng"
-        ] = place.geometry.location.lng();
-        locationArray["hometown_address"]["form_address"] = $(
-          "#autocomplete_hometown"
-        ).val();
-      }
-    } catch (err) {
-      console.log(err);
+  );
+  gnl.location.bindAutocomplete(
+    locationArray,
+    "autocomplete_hometown",
+    "hometown_address",
+    function hometownAddress() {
+      $("#autocomplete_hometown").val();
     }
-  });
+  );
 }
 
 $("#cancelButton").click(function() {

--- a/public/profile.js
+++ b/public/profile.js
@@ -19,7 +19,7 @@ firebase.firestore().settings(settings);
  * Register event callbacks & implement element callbacks
  ******************************************************/
 // Start execution when page is done loading
-$(document).ready(function () { });
+$(document).ready(function() {});
 
 function renderWithUser(user) {
   $("#mainPage").show();
@@ -43,14 +43,14 @@ function renderWithoutUser() {
 gnl.auth.listenForStageChange(renderWithUser, renderWithoutUser, false);
 
 // Prevent the enter key from submitting the form when uncomplete
-$(window).keydown(function (event) {
+$(window).keydown(function(event) {
   if (event.keyCode == 13) {
     event.preventDefault();
     return false;
   }
 });
 // MUN grad change event
-$("#MUN").on("change", function () {
+$("#MUN").on("change", function() {
   if ($(this).val() === "Yes") {
     $("#grad_year").show();
   } else {
@@ -71,13 +71,13 @@ function initAutocomplete() {
   // Register our autocomplete elements, see URL for more information
   // https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
   autocomplete_current = new google.maps.places.Autocomplete(
-    /** @type {!HTMLInputElement} */(document.getElementById(
+    /** @type {!HTMLInputElement} */ (document.getElementById(
       "autocomplete_current"
     )),
     { types: ["geocode"] }
   );
   autocomplete_hometown = new google.maps.places.Autocomplete(
-    /** @type {!HTMLInputElement} */(document.getElementById(
+    /** @type {!HTMLInputElement} */ (document.getElementById(
       "autocomplete_hometown"
     )),
     { types: ["geocode"] }
@@ -96,7 +96,7 @@ function initAutocomplete() {
 
   // define event callbacks for each element, these fire when the fields
   // are auto filled by google api and then the location data is stored in our member object
-  autocomplete_current.addListener("place_changed", function () {
+  autocomplete_current.addListener("place_changed", function() {
     try {
       // Get place object from google api
       var place = autocomplete_current.getPlace();
@@ -136,7 +136,7 @@ function initAutocomplete() {
 
   // Second autocomplete callback, the repeated code kills me but im currently lazy
   // TODO: tear out the repeated code into a function above
-  autocomplete_hometown.addListener("place_changed", function () {
+  autocomplete_hometown.addListener("place_changed", function() {
     try {
       // Get place object from google api
       var place = autocomplete_hometown.getPlace();
@@ -180,13 +180,13 @@ function initAutocomplete() {
   });
 }
 
-$("#cancelButton").click(function () {
+$("#cancelButton").click(function() {
   event.preventDefault();
   window.location.replace("index.html");
 });
 
 // form submit callback
-$("#profile_form").submit(function (event) {
+$("#profile_form").submit(function(event) {
   // prevent navigation out of page
   event.preventDefault();
   /* Store known fields into member objcet
@@ -238,20 +238,20 @@ $("#profile_form").submit(function (event) {
 
   const memberDatabaseTask = memberDocRef
     .set(member, { merge: true })
-    .then(function () {
+    .then(function() {
       console.log("Successfully wrote to public database");
     })
-    .catch(function (error) {
+    .catch(function(error) {
       console.log(error);
       console.log("Error writing public database properties for ", uid);
     });
 
   const privateDatabaseTask = privateDocRef
     .set(private_data, { merge: true })
-    .then(function () {
+    .then(function() {
       console.log("Successfully wrote to private database");
     })
-    .catch(function (error) {
+    .catch(function(error) {
       console.log(error);
       console.log("Error writing private database properties for ", uid);
     });

--- a/public/profile.js
+++ b/public/profile.js
@@ -452,16 +452,3 @@ function getLocationString(locationObject) {
   // Filter array for unwanted data, then join with ', ' to create a comma separated string from data
   return location.filter(e => e !== "" && e !== undefined).join(", ");
 }
-
-/**
- * Returns the value of the given URL query parameter.
- */
-function getURLParameter(name) {
-  return (
-    decodeURIComponent(
-      (new RegExp("[?|&]" + name + "=" + "([^&;]+?)(&|#|;|$)").exec(
-        location.search
-      ) || [null, ""])[1].replace(/\+/g, "%20")
-    ) || null
-  );
-}

--- a/public/profile.js
+++ b/public/profile.js
@@ -1,6 +1,6 @@
 /******************************************************
-* Global variables
-******************************************************/
+ * Global variables
+ ******************************************************/
 
 var uid;
 var memberDocRef;
@@ -14,339 +14,367 @@ const loggedinUserBar = `<li class="nav-item" id="login_name_nav"><a class="nav-
 			<li class="nav-item"><a class="nav-link" href="profile.html"><span class="fas fa-globalnl fa-edit"></span><span id="">Edit profile</span></a></li>
 			<li id="button_logout" class="nav-item"><a class="nav-link" href="#"><span class="fas fa-globalnl fa-sign-out-alt"></span><span id="">Logout</span></a></li>`;
 
-/*****************************************************  
-* Firestore
-******************************************************/
+/*****************************************************
+ * Firestore
+ ******************************************************/
 
-const settings = {timestampsInSnapshots: true};
+const settings = { timestampsInSnapshots: true };
 firebase.firestore().settings(settings);
 
-
-/*****************************************************  
-* Register event callbacks & implement element callbacks
-******************************************************/
+/*****************************************************
+ * Register event callbacks & implement element callbacks
+ ******************************************************/
 // Start execution when page is done loading
-$(document).ready(function(){
-  
-  
-  
-});
-
+$(document).ready(function() {});
 
 firebase.auth().onAuthStateChanged(function(user) {
-  $( "#members-list" ).empty();
+  $("#members-list").empty();
   if (user) {
     // User logged in.
-	$("#loginPage").hide();
-	$("#mainPage").show();
-	$('#userNavBar').html(loggedinUserBar);
-	uid = firebase.auth().currentUser.uid;
-	memberDocRef = firebase.firestore().collection('members').doc(uid);
-	privateDocRef = firebase.firestore().collection('private_data').doc(uid);
-	// Load user information at top of page for desktop
-	$('#login_name').html(firebase.auth().currentUser.displayName);
-	$('#display_name').val(firebase.auth().currentUser.displayName);
-	$('#button_logout').click(function(e){
-		// Cancel the default action
-		e.preventDefault();
-		logout();
-		clickNavBar();
-	});
-	initApp();
+    $("#loginPage").hide();
+    $("#mainPage").show();
+    $("#userNavBar").html(loggedinUserBar);
+    uid = firebase.auth().currentUser.uid;
+    memberDocRef = firebase
+      .firestore()
+      .collection("members")
+      .doc(uid);
+    privateDocRef = firebase
+      .firestore()
+      .collection("private_data")
+      .doc(uid);
+    // Load user information at top of page for desktop
+    $("#login_name").html(firebase.auth().currentUser.displayName);
+    $("#display_name").val(firebase.auth().currentUser.displayName);
+    $("#button_logout").click(function(e) {
+      // Cancel the default action
+      e.preventDefault();
+      logout();
+      clickNavBar();
+    });
+    initApp();
   } else {
-	$('#userNavBar').html(defaultUserBar);
-	$("#mainPage").hide();
-	$("#loginPage").show();
+    $("#userNavBar").html(defaultUserBar);
+    $("#mainPage").hide();
+    $("#loginPage").show();
   }
 });
 
-function LIlogin(){
-	window.open('login.html','targetWindow','toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=no,width=585,height=600');
+function LIlogin() {
+  window.open(
+    "login.html",
+    "targetWindow",
+    "toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=no,width=585,height=600"
+  );
 }
-
 
 // Logout callback
 function logout() {
-    firebase.auth().signOut().then(function() {
-        console.log('Signed Out');
+  firebase
+    .auth()
+    .signOut()
+    .then(
+      function() {
+        console.log("Signed Out");
         //window.location.href = "index.html";
-    }, function(error) {
-        console.error('Sign Out Error', error);
-    });
+      },
+      function(error) {
+        console.error("Sign Out Error", error);
+      }
+    );
 }
 
-function clickNavBar(){
-	if($('.navbar-toggler').css('display') !='none'){
-		$('.navbar-toggler').trigger( "click" );
-	}
+function clickNavBar() {
+  if ($(".navbar-toggler").css("display") != "none") {
+    $(".navbar-toggler").trigger("click");
+  }
 }
 
 // Prevent the enter key from submitting the form when uncomplete
-$(window).keydown(function(event){
-    if(event.keyCode == 13) {
-      event.preventDefault();
-      return false;
-    }
+$(window).keydown(function(event) {
+  if (event.keyCode == 13) {
+    event.preventDefault();
+    return false;
+  }
 });
 // MUN grad change event
-$('#MUN').on('change',function(){
-    if( $(this).val()==="Yes"){
-      $("#grad_year").show();
-    }
-    else {
-      $("#grad_year").hide();
-    }
+$("#MUN").on("change", function() {
+  if ($(this).val() === "Yes") {
+    $("#grad_year").show();
+  } else {
+    $("#grad_year").hide();
+  }
 });
 // Industry change event
-function changeMUN(){
-    if ($( "#MUN" ).val() == "Yes") {
-        document.getElementById("MUN_grad_year_box").required = true;
-    }
-    else {
-        document.getElementById("MUN_grad_year_box").required = false;
-    }
+function changeMUN() {
+  if ($("#MUN").val() == "Yes") {
+    document.getElementById("MUN_grad_year_box").required = true;
+  } else {
+    document.getElementById("MUN_grad_year_box").required = false;
+  }
 }
 // Callback for google maps autocomplete for storing autocompleted location data into
 // the new member objcet
 function initAutocomplete() {
-    // Register our autocomplete elements, see URL for more information
-    // https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
-    autocomplete_current = new google.maps.places.Autocomplete(
-        /** @type {!HTMLInputElement} */(document.getElementById('autocomplete_current')),
-        {types: ['geocode']});
-    autocomplete_hometown = new google.maps.places.Autocomplete(
-        /** @type {!HTMLInputElement} */(document.getElementById('autocomplete_hometown')),
-        {types: ['geocode']});
+  // Register our autocomplete elements, see URL for more information
+  // https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
+  autocomplete_current = new google.maps.places.Autocomplete(
+    /** @type {!HTMLInputElement} */ (document.getElementById(
+      "autocomplete_current"
+    )),
+    { types: ["geocode"] }
+  );
+  autocomplete_hometown = new google.maps.places.Autocomplete(
+    /** @type {!HTMLInputElement} */ (document.getElementById(
+      "autocomplete_hometown"
+    )),
+    { types: ["geocode"] }
+  );
 
-    // Look for these keys in the place object returned by google API
-    // if found, their values are filled and written to our new member object
-    var locationData = {
-        street_number               : true,
-        route                       : true,
-        locality                    : true,
-        administrative_area_level_1 : true,
-        country                     : true,
-        postal_code                 : true
-    };
+  // Look for these keys in the place object returned by google API
+  // if found, their values are filled and written to our new member object
+  var locationData = {
+    street_number: true,
+    route: true,
+    locality: true,
+    administrative_area_level_1: true,
+    country: true,
+    postal_code: true
+  };
 
-    // define event callbacks for each element, these fire when the fields
-    // are auto filled by google api and then the location data is stored in our member object
-    autocomplete_current.addListener('place_changed', function(){
-        try{
-            // Get place object from google api
-            var place = autocomplete_current.getPlace();
-            if(place){
-                // iterate over object and look for the keys in locationData
-                locationArray["current_address"] = {
-					locality: null,
-					administrative_area_level_1 : null,  
-					country: null,  
-					locality_short: null,
-					administrative_area_level_1_short : null,  
-					country_short: null, 
-					postal_code: null,
-					lat: null,  
-					lng: null
-				};
-                for (var i = 0; i < place.address_components.length; i++) {
-                    var addressType = place.address_components[i].types[0];
-                    if (locationData.hasOwnProperty(addressType)) {
-                        locationArray["current_address"][addressType] = place.address_components[i]["long_name"];
-						locationArray["current_address"][addressType + "_short"] = place.address_components[i]["short_name"];
-                    }
-                }
-                // Store geometry into new member object as well
-                locationArray["current_address"]["lat"] = place.geometry.location.lat();
-                locationArray["current_address"]["lng"] = place.geometry.location.lng();
-				locationArray["current_address"]["form_address"] = $("#autocomplete_current").val();
-				
-            }
-        }catch(err){
-            console.log(err);
+  // define event callbacks for each element, these fire when the fields
+  // are auto filled by google api and then the location data is stored in our member object
+  autocomplete_current.addListener("place_changed", function() {
+    try {
+      // Get place object from google api
+      var place = autocomplete_current.getPlace();
+      if (place) {
+        // iterate over object and look for the keys in locationData
+        locationArray["current_address"] = {
+          locality: null,
+          administrative_area_level_1: null,
+          country: null,
+          locality_short: null,
+          administrative_area_level_1_short: null,
+          country_short: null,
+          postal_code: null,
+          lat: null,
+          lng: null
+        };
+        for (var i = 0; i < place.address_components.length; i++) {
+          var addressType = place.address_components[i].types[0];
+          if (locationData.hasOwnProperty(addressType)) {
+            locationArray["current_address"][addressType] =
+              place.address_components[i]["long_name"];
+            locationArray["current_address"][addressType + "_short"] =
+              place.address_components[i]["short_name"];
+          }
         }
-    });
+        // Store geometry into new member object as well
+        locationArray["current_address"]["lat"] = place.geometry.location.lat();
+        locationArray["current_address"]["lng"] = place.geometry.location.lng();
+        locationArray["current_address"]["form_address"] = $(
+          "#autocomplete_current"
+        ).val();
+      }
+    } catch (err) {
+      console.log(err);
+    }
+  });
 
-    // Second autocomplete callback, the repeated code kills me but im currently lazy
-    // TODO: tear out the repeated code into a function above
-    autocomplete_hometown.addListener('place_changed', function() {
-        try{
-            // Get place object from google api
-            var place = autocomplete_hometown.getPlace();
-            if(place){
-                // iterate over object and look for the keys in locationData
-                locationArray["hometown_address"] = {
-					locality: null,
-					administrative_area_level_1 : null,  
-					country: null,  
-					locality_short: null,
-					administrative_area_level_1_short : null,  
-					country_short: null, 
-					postal_code: null,
-					lat: null,  
-					lng: null
-				};
+  // Second autocomplete callback, the repeated code kills me but im currently lazy
+  // TODO: tear out the repeated code into a function above
+  autocomplete_hometown.addListener("place_changed", function() {
+    try {
+      // Get place object from google api
+      var place = autocomplete_hometown.getPlace();
+      if (place) {
+        // iterate over object and look for the keys in locationData
+        locationArray["hometown_address"] = {
+          locality: null,
+          administrative_area_level_1: null,
+          country: null,
+          locality_short: null,
+          administrative_area_level_1_short: null,
+          country_short: null,
+          postal_code: null,
+          lat: null,
+          lng: null
+        };
 
-                for (var i = 0; i < place.address_components.length; i++) {
-                var addressType = place.address_components[i].types[0];
-                    if (locationData.hasOwnProperty(addressType) ){
-                        locationArray["hometown_address"][addressType] = place.address_components[i]["long_name"];
-						locationArray["hometown_address"][addressType + "_short"] = place.address_components[i]["short_name"];
-                    }
-                }
-                // Store geometry into new member object as well
-                locationArray["hometown_address"]["lat"] = place.geometry.location.lat();
-                locationArray["hometown_address"]["lng"] = place.geometry.location.lng();
-				locationArray["hometown_address"]["form_address"] = $("#autocomplete_hometown").val();
-            }
-        }catch(err){
-            console.log(err);
+        for (var i = 0; i < place.address_components.length; i++) {
+          var addressType = place.address_components[i].types[0];
+          if (locationData.hasOwnProperty(addressType)) {
+            locationArray["hometown_address"][addressType] =
+              place.address_components[i]["long_name"];
+            locationArray["hometown_address"][addressType + "_short"] =
+              place.address_components[i]["short_name"];
+          }
         }
-    });
+        // Store geometry into new member object as well
+        locationArray["hometown_address"][
+          "lat"
+        ] = place.geometry.location.lat();
+        locationArray["hometown_address"][
+          "lng"
+        ] = place.geometry.location.lng();
+        locationArray["hometown_address"]["form_address"] = $(
+          "#autocomplete_hometown"
+        ).val();
+      }
+    } catch (err) {
+      console.log(err);
+    }
+  });
 }
 
-$( "#cancelButton" ).click(function() {
-	event.preventDefault();
-	window.location.replace("index.html");
+$("#cancelButton").click(function() {
+  event.preventDefault();
+  window.location.replace("index.html");
 });
 
 // form submit callback
-$("#profile_form").submit(  function(event){
-    // prevent navigation out of page
-    event.preventDefault();
-    /* Store known fields into member objcet
+$("#profile_form").submit(function(event) {
+  // prevent navigation out of page
+  event.preventDefault();
+  /* Store known fields into member objcet
     */
-//  var memberGeo = {
-//  };
-   var member = {};
-   member.display_name = $( "#display_name" ).val();
-   member.MUN = $( "#MUN" ).val();
-   member.privacy = $('input[name=privacy]:checked').val();
-   member.date_updated = Date.now();
-   // Conditional reads
-   if (member.MUN == "Yes") {
-       member["MUN_grad_year"] = parseInt($( "#MUN_grad_year_box" ).val());
-   }
+  //  var memberGeo = {
+  //  };
+  var member = {};
+  member.display_name = $("#display_name").val();
+  member.MUN = $("#MUN").val();
+  member.privacy = $("input[name=privacy]:checked").val();
+  member.date_updated = Date.now();
+  // Conditional reads
+  if (member.MUN == "Yes") {
+    member["MUN_grad_year"] = parseInt($("#MUN_grad_year_box").val());
+  }
 
-	// checkif hometown address was given
-	if(locationArray.hasOwnProperty("hometown_address"))
-	{
-		member["hometown_address"] = locationArray["hometown_address"];
-	//	memberGeo.id = uid;
-	//	memberGeo.hometownLat = locationArray["hometown_address"]["lat"];
-	//	memberGeo.hometownLng = locationArray["hometown_address"]["lng"];
-	}
-	// checkif current address was given
-	if(locationArray.hasOwnProperty("current_address"))
-	{
-		member["current_address"] = locationArray["current_address"];
-	//	memberGeo.id = uid;
-	//	memberGeo.currentLat = locationArray["current_address"]["lat"];
-	//	memberGeo.currentLng = locationArray["current_address"]["lng"];
-	}
-	
-	//if(memberGeo.id){
-	//	$.post( "GeoUser", memberGeo , function(data, status, jqXHR) {console.log('status: ' + status + ', data: ' + data);})
-	//}
-	
-	member.bio = $( "#bio" ).val();
-	
-	var private_data = {};
-	
-	private_data["interests"] = {
-        "connect" : document.getElementById('connect').checked,
-        "organize" : document.getElementById('organize').checked,
-        "learn" : document.getElementById('learn').checked,
-        "mentor" : document.getElementById('mentor').checked,
-        "support" : document.getElementById('support').checked
-    }
-	
-	private_data.comments = $( "#comments" ).text();
+  // checkif hometown address was given
+  if (locationArray.hasOwnProperty("hometown_address")) {
+    member["hometown_address"] = locationArray["hometown_address"];
+    //	memberGeo.id = uid;
+    //	memberGeo.hometownLat = locationArray["hometown_address"]["lat"];
+    //	memberGeo.hometownLng = locationArray["hometown_address"]["lng"];
+  }
+  // checkif current address was given
+  if (locationArray.hasOwnProperty("current_address")) {
+    member["current_address"] = locationArray["current_address"];
+    //	memberGeo.id = uid;
+    //	memberGeo.currentLat = locationArray["current_address"]["lat"];
+    //	memberGeo.currentLng = locationArray["current_address"]["lng"];
+  }
 
-	const memberDatabaseTask = memberDocRef.set(
-	member,
-	{merge: true}
-	).then(function(){
-	  console.log("Successfully wrote to public database");
-	}).catch(function(error){
-	  console.log(error);
-	  console.log("Error writing public database properties for ", uid);
-	});	
-	
-	const privateDatabaseTask = privateDocRef.set(
-	private_data,
-	{merge: true}
-	).then(function(){
-	  console.log("Successfully wrote to private database");
-	}).catch(function(error){
-	  console.log(error);
-	  console.log("Error writing private database properties for ", uid);
-	});
-	
-	return Promise.all([memberDatabaseTask, privateDatabaseTask]).then(() => {
-		console.log("Completed both database writes");
-		window.location.replace("index.html");
-	});
-    
-})
+  //if(memberGeo.id){
+  //	$.post( "GeoUser", memberGeo , function(data, status, jqXHR) {console.log('status: ' + status + ', data: ' + data);})
+  //}
 
+  member.bio = $("#bio").val();
+
+  var private_data = {};
+
+  private_data["interests"] = {
+    connect: document.getElementById("connect").checked,
+    organize: document.getElementById("organize").checked,
+    learn: document.getElementById("learn").checked,
+    mentor: document.getElementById("mentor").checked,
+    support: document.getElementById("support").checked
+  };
+
+  private_data.comments = $("#comments").text();
+
+  const memberDatabaseTask = memberDocRef
+    .set(member, { merge: true })
+    .then(function() {
+      console.log("Successfully wrote to public database");
+    })
+    .catch(function(error) {
+      console.log(error);
+      console.log("Error writing public database properties for ", uid);
+    });
+
+  const privateDatabaseTask = privateDocRef
+    .set(private_data, { merge: true })
+    .then(function() {
+      console.log("Successfully wrote to private database");
+    })
+    .catch(function(error) {
+      console.log(error);
+      console.log("Error writing private database properties for ", uid);
+    });
+
+  return Promise.all([memberDatabaseTask, privateDatabaseTask]).then(() => {
+    console.log("Completed both database writes");
+    window.location.replace("index.html");
+  });
+});
 
 /********************************
-* Main namespace and control flow
-*********************************/
+ * Main namespace and control flow
+ *********************************/
 
-function initApp(){
-
-var getMemberDoc = memberDocRef.get()
+function initApp() {
+  var getMemberDoc = memberDocRef
+    .get()
     .then(doc => {
       if (!doc.exists) {
-        console.log('No such document!');
+        console.log("No such document!");
       } else {
-		userData = doc.data();
-		//console.log(userData);
-		if(!userData["date_updated"]){
-			$('#alertbox').html("Welcome to Global NL!<br/>We're looking forward to getting to know you better. Please complete your profile below.");
-			$('#alertbox').show();
-			$('#cancelButton').hide();
-		}
-		else if(userData["date_updated"] == "-1"){ //Can change this to so many days back later
-			$('#alertbox').html("Welcome back to Global NL!<br/>It's been a while since you've logged in so please review your profile before continuing.");
-			$('#alertbox').show();
-			$('#cancelButton').hide();
-		}
-		if(userData["current_address"] != null){
-			if(userData["current_address"]["form_address"] != null) 
-				$("#autocomplete_current").val( userData["current_address"]["form_address"] );
-			else
-				$("#autocomplete_current").val( getLocationString(userData["current_address"]) );
-			locationArray["current_address"] = userData["current_address"];
-		}
-		if(userData["hometown_address"] != null){
-			if(userData["hometown_address"]["form_address"] != null)
-				$("#autocomplete_hometown").val( userData["hometown_address"]["form_address"] );
-			else
-				$("#autocomplete_hometown").val( getLocationString(userData["hometown_address"]) );
-			locationArray["hometown_address"] = userData["hometown_address"];
-		}
-		if(userData["MUN"] != null)
-			$("#MUN").val(userData["MUN"]);
-		if(userData["MUN"] === "Yes")
-			$("#grad_year").show()
-		if(userData["MUN_grad_year"] != null)
-			$("#MUN_grad_year_box").val( userData["MUN_grad_year"] );
-		
-		if(userData["bio"] != null)
-			$("#bio").text(userData["bio"]);
+        userData = doc.data();
+        //console.log(userData);
+        if (!userData["date_updated"]) {
+          $("#alertbox").html(
+            "Welcome to Global NL!<br/>We're looking forward to getting to know you better. Please complete your profile below."
+          );
+          $("#alertbox").show();
+          $("#cancelButton").hide();
+        } else if (userData["date_updated"] == "-1") {
+          //Can change this to so many days back later
+          $("#alertbox").html(
+            "Welcome back to Global NL!<br/>It's been a while since you've logged in so please review your profile before continuing."
+          );
+          $("#alertbox").show();
+          $("#cancelButton").hide();
+        }
+        if (userData["current_address"] != null) {
+          if (userData["current_address"]["form_address"] != null)
+            $("#autocomplete_current").val(
+              userData["current_address"]["form_address"]
+            );
+          else
+            $("#autocomplete_current").val(
+              getLocationString(userData["current_address"])
+            );
+          locationArray["current_address"] = userData["current_address"];
+        }
+        if (userData["hometown_address"] != null) {
+          if (userData["hometown_address"]["form_address"] != null)
+            $("#autocomplete_hometown").val(
+              userData["hometown_address"]["form_address"]
+            );
+          else
+            $("#autocomplete_hometown").val(
+              getLocationString(userData["hometown_address"])
+            );
+          locationArray["hometown_address"] = userData["hometown_address"];
+        }
+        if (userData["MUN"] != null) $("#MUN").val(userData["MUN"]);
+        if (userData["MUN"] === "Yes") $("#grad_year").show();
+        if (userData["MUN_grad_year"] != null)
+          $("#MUN_grad_year_box").val(userData["MUN_grad_year"]);
 
+        if (userData["bio"] != null) $("#bio").text(userData["bio"]);
 
-		// Privacy
-		if( userData["privacy"] === "public" ){
-			$(':input[value="public"]').prop("checked", true);
-		}else{
-			$(':input[value="members"]').prop("checked", true);
-		}
+        // Privacy
+        if (userData["privacy"] === "public") {
+          $(':input[value="public"]').prop("checked", true);
+        } else {
+          $(':input[value="members"]').prop("checked", true);
+        }
 
-		//Use LinkedIn location if current location not set
-		/*
+        //Use LinkedIn location if current location not set
+        /*
 		if(userData["current_address"] != null && !userData["current_address"]["form_address"] && userData["current_address"]["LinkedInLocation"] && userData["current_address"]["LinkedInLocation"] != "Newfoundland And Labrador, Canada"){
 			
 			var linkedinLocation = userData["current_address"]["LinkedInLocation"].replace(' Area', '');
@@ -400,67 +428,70 @@ var getMemberDoc = memberDocRef.get()
       }
     })
     .catch(err => {
-      console.log('Error getting document', err);
+      console.log("Error getting document", err);
     });
-	
 
-var getPrivateDoc = privateDocRef.get()
+  var getPrivateDoc = privateDocRef
+    .get()
     .then(doc => {
       if (!doc.exists) {
-        console.log('No such document!');
+        console.log("No such document!");
       } else {
-		userData = doc.data();
-		// Iterate over interests and check respective fields
-		if(userData["interests"] != null){
-			for ( const [interest, value] of Object.entries(userData.interests) ){
-				// Check if interst exists
-				if( value && document.getElementById(interest) ){
-					//Check the button
-					$("#"+interest).prop("checked", true);
-				}
-			}
-		}
-		// Fill comments block
-		if(userData["comments"] != null)
-		$("#comments").text(userData["comments"]);
-		}
+        userData = doc.data();
+        // Iterate over interests and check respective fields
+        if (userData["interests"] != null) {
+          for (const [interest, value] of Object.entries(userData.interests)) {
+            // Check if interst exists
+            if (value && document.getElementById(interest)) {
+              //Check the button
+              $("#" + interest).prop("checked", true);
+            }
+          }
+        }
+        // Fill comments block
+        if (userData["comments"] != null)
+          $("#comments").text(userData["comments"]);
+      }
     })
     .catch(err => {
-      console.log('Error getting document', err);
+      console.log("Error getting document", err);
     });
-
-
-
 }
 
-
 /*****************************************************
-* Utility Functions, only referenced in this file
-*****************************************************/
+ * Utility Functions, only referenced in this file
+ *****************************************************/
 /* Build location string
     Concatonate the data in the location value from a member object
     into a formatted string
     @param locationObject (Object{}) - value from location field (Either past or current) from firebase
 */
-function getLocationString(locationObject)
-{
-    // Initalize empty array to work with
-    var location = [];
-    // Append all required data to array
-	if(locationObject.locality_short) location.push(locationObject.locality_short); else if(locationObject.locality) location.push(locationObject.locality);
-	if(locationObject.administrative_area_level_1_short) location.push(locationObject.administrative_area_level_1_short); else if(locationObject.administrative_area_level_1) location.push(locationObject.administrative_area_level_1);
-	if(locationObject.country) location.push(locationObject.country);
-    //location.push(locationObject.locality, locationObject.administrative_area_level_1, locationObject.country);
-    // Filter array for unwanted data, then join with ', ' to create a comma separated string from data
-    return location.filter(e => e !== "" && e !== undefined).join(", "); 
+function getLocationString(locationObject) {
+  // Initalize empty array to work with
+  var location = [];
+  // Append all required data to array
+  if (locationObject.locality_short)
+    location.push(locationObject.locality_short);
+  else if (locationObject.locality) location.push(locationObject.locality);
+  if (locationObject.administrative_area_level_1_short)
+    location.push(locationObject.administrative_area_level_1_short);
+  else if (locationObject.administrative_area_level_1)
+    location.push(locationObject.administrative_area_level_1);
+  if (locationObject.country) location.push(locationObject.country);
+  //location.push(locationObject.locality, locationObject.administrative_area_level_1, locationObject.country);
+  // Filter array for unwanted data, then join with ', ' to create a comma separated string from data
+  return location.filter(e => e !== "" && e !== undefined).join(", ");
 }
 
-  /**
-   * Returns the value of the given URL query parameter.
-   */
-  function getURLParameter(name) {
-    return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search) ||
-        [null, ''])[1].replace(/\+/g, '%20')) || null;
-  }
-
-
+/**
+ * Returns the value of the given URL query parameter.
+ */
+function getURLParameter(name) {
+  return (
+    decodeURIComponent(
+      (new RegExp("[?|&]" + name + "=" + "([^&;]+?)(&|#|;|$)").exec(
+        location.search
+      ) || [null, ""])[1].replace(/\+/g, "%20")
+    ) || null
+  );
+}

--- a/public/profile.js
+++ b/public/profile.js
@@ -49,7 +49,7 @@ firebase.auth().onAuthStateChanged(function(user) {
     $("#button_logout").click(function(e) {
       // Cancel the default action
       e.preventDefault();
-      logout();
+      gnl.auth.logout();
       clickNavBar();
     });
     initApp();
@@ -59,22 +59,6 @@ firebase.auth().onAuthStateChanged(function(user) {
     $("#loginPage").show();
   }
 });
-
-// Logout callback
-function logout() {
-  firebase
-    .auth()
-    .signOut()
-    .then(
-      function() {
-        console.log("Signed Out");
-        //window.location.href = "index.html";
-      },
-      function(error) {
-        console.error("Sign Out Error", error);
-      }
-    );
-}
 
 function clickNavBar() {
   if ($(".navbar-toggler").css("display") != "none") {

--- a/public/profile.js
+++ b/public/profile.js
@@ -8,12 +8,6 @@ var privateDocRef;
 // For storing current location and hometown from Google Maps
 var locationArray = {};
 
-const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();gnl.navBar.toggle();return false;" ><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>`;
-
-const loggedinUserBar = `<li class="nav-item" id="login_name_nav"><a class="nav-link" href="#"><span class="fas fa-globalnl fa-user"></span><span id="login_name"></span></a></li>
-			<li class="nav-item"><a class="nav-link" href="profile.html"><span class="fas fa-globalnl fa-edit"></span><span id="">Edit profile</span></a></li>
-			<li id="button_logout" class="nav-item"><a class="nav-link" href="#"><span class="fas fa-globalnl fa-sign-out-alt"></span><span id="">Logout</span></a></li>`;
-
 /*****************************************************
  * Firestore
  ******************************************************/
@@ -46,7 +40,7 @@ function renderWithoutUser() {
   $("#mainPage").hide();
 }
 
-gnl.auth.listenForStageChange(renderWithUser, renderWithoutUser);
+gnl.auth.listenForStageChange(renderWithUser, renderWithoutUser, false);
 
 // Prevent the enter key from submitting the form when uncomplete
 $(window).keydown(function (event) {

--- a/public/profile.js
+++ b/public/profile.js
@@ -8,7 +8,7 @@ var privateDocRef;
 // For storing current location and hometown from Google Maps
 var locationArray = {};
 
-const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="LIlogin();clickNavBar();return false;" ><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>`;
+const defaultUserBar = `<li class="nav-item"><a class="nav-link" href="#" onClick="gnl.auth.loginLinkedIn();clickNavBar();return false;" ><span class="fas fa-globalnl fa-user"></span><span>Sign in</span></a></li>`;
 
 const loggedinUserBar = `<li class="nav-item" id="login_name_nav"><a class="nav-link" href="#"><span class="fas fa-globalnl fa-user"></span><span id="login_name"></span></a></li>
 			<li class="nav-item"><a class="nav-link" href="profile.html"><span class="fas fa-globalnl fa-edit"></span><span id="">Edit profile</span></a></li>
@@ -59,14 +59,6 @@ firebase.auth().onAuthStateChanged(function(user) {
     $("#loginPage").show();
   }
 });
-
-function LIlogin() {
-  window.open(
-    "login.html",
-    "targetWindow",
-    "toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=no,width=585,height=600"
-  );
-}
 
 // Logout callback
 function logout() {

--- a/public/vTabs.css
+++ b/public/vTabs.css
@@ -4,14 +4,14 @@
   display: flex;
   flex-flow: column nowrap;
 }
-.nav-tabs--vertical li{
-	font-size: 1.2rem;
-	text-align: center;
+.nav-tabs--vertical li {
+  font-size: 1.2rem;
+  text-align: center;
 }
-.tab-pane h1{
-	font-size: 1rem;
-	padding-top: 0.8rem;
-	padding-bottom: 0.8rem;
+.tab-pane h1 {
+  font-size: 1rem;
+  padding-top: 0.8rem;
+  padding-bottom: 0.8rem;
 }
 .nav-tabs--left {
   margin: 0 15px 0 4px;


### PR DESCRIPTION
- Ignores service account configurations to avoid accidentally staging them into a commit in the future
- Format all JS and CSS code with [Prettier](https://github.com/prettier/prettier) using `prettier --write "**/*.js"` or `prettier --write "**/*.css"`
  - This will make it easier for new contributors to follow the same code style, and auto-format on save is really nice in general
- Add a temporary global named `gnl` to `window` so we can share code like the LinkedIn login, logout, navbar toggle, etc.
  - The `gnl` global is created using an [IIFE](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression), so we don't any other variables/functions as globals to control which parts are shared
  - Eventually when we refactor the codebase to produce a single-page application (i.e. React/Vue/something), we can simply use ES6 modules to get similar behavior, and create a single JS bundle