### PR TITLE
LinkedIn Badge fix and Load member profile from URL

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -63,21 +63,21 @@ exports.sendWelcomeEmail = functions.auth.user().onCreate(user => {
   var promiseArray = [];
   promiseArray.push(sendWelcomeEmail(email, displayName));
   promiseArray.push(mailchimp.post(
-			`/lists/${mailchimpListID}/members`,
-			{
-				email_address: email,
-				status: 'subscribed',
-				merge_fields:{FNAME: displayName}
-			}
-			)
-			.then((response)=>{
-				console.log(email + ' added to Mailchimp');
-				console.log(response);
-			}));
+      `/lists/${mailchimpListID}/members`,
+      {
+        email_address: email,
+        status: 'subscribed',
+        merge_fields:{FNAME: displayName}
+      }
+      )
+      .then((response)=>{
+        console.log(email + ' added to Mailchimp');
+        console.log(response);
+      }));
     return Promise.all(promiseArray)
-	.catch(err => {
-		console.error(err);
-	});
+  .catch(err => {
+    console.error(err);
+  });
 });
 
 exports.sendMessageToUser = functions.https.onCall((data, context) => {
@@ -271,12 +271,22 @@ exports.token = functions.https.onRequest((req, res) => {
             date_signedin: Date.now()
           };
 
+          var photoURL = 'https://members.globalnl.com/assets/ghost_person_200x200_v1.png';
+          if (userResults.profilePicture && userResults.profilePicture['displayImage~'] && userResults.profilePicture['displayImage~'].elements[0] && userResults.profilePicture['displayImage~'].elements[0].identifiers[0] && userResults.profilePicture['displayImage~'].elements[0].identifiers[0].identifier) {
+            photoURL = userResults.profilePicture['displayImage~'].elements[0].identifiers[0].identifier;
+          }
+
+          var emailAddress = 'connect@globalnl.com';
+          if (userEmail && userEmail.elements[0] && userEmail.elements[0]['handle~'] && userEmail.elements[0]['handle~']['emailAddress']) {
+            emailAddress = userEmail.elements[0]['handle~']['emailAddress'];
+          }
+
           // Create a Firebase account and get the Custom Auth Token.
           return createFirebaseAccount(
             "00LI_" + userResults.id,
             member.first_name + ' ' + member.last_name,
-            userResults.profilePicture['displayImage~'].elements[0].identifiers[0].identifier,//userResults.pictureUrl,
-            userEmail.elements[0]['handle~']['emailAddress']
+            photoURL,//userResults.pictureUrl,
+            emailAddress
           ).then(firebaseToken => {
               // Serve an HTML page that signs the user in and updates the user profile.
               return res.jsonp({

--- a/public/globalnl.css
+++ b/public/globalnl.css
@@ -252,15 +252,15 @@ h1.welcome-text {
 }
 
 .LI-badge-container {
-	width: 100% !important;
-	-webkit-box-shadow:none !important;
-	-moz-box-shadow:none !important;
-	box-shadow:none !important;	
+  width: 100% !important;
+  -webkit-box-shadow:none !important;
+  -moz-box-shadow:none !important;
+  box-shadow:none !important; 
 }
 
 .LI-profile-pic {
-	width: 70px !important;
-	height: 70px !important;
+  width: 70px !important;
+  height: 70px !important;
 }
 
 .fa-globalnl {
@@ -381,7 +381,7 @@ input:checked + .slider:before {
 }
 
 .input-group {
-	margin-bottom: 10px;
+  margin-bottom: 10px;
 }
 
 .col-form-label {
@@ -485,4 +485,1911 @@ input:checked + .slider:before {
   #LIbadge {
     max-width: 415.796px;
   }
+}
+
+a.artdeco-button {
+  text-decoration: none
+}
+
+a.artdeco-button:hover,
+a.artdeco-button:active,
+a.artdeco-button:focus,
+a.artdeco-button:visited {
+  text-decoration: none
+}
+
+.artdeco-button,
+.artdeco-button--primary,
+a.artdeco-button--primary {
+  background-color: #0073b1;
+  color: #fff
+}
+
+.artdeco-button:visited,
+.artdeco-button--primary:visited,
+.artdeco-button:visited:hover,
+.artdeco-button--primary:visited:hover {
+  background-color: #0073b1;
+  color: #fff
+}
+
+.artdeco-button:hover,
+.artdeco-button--primary:hover,
+.artdeco-button:focus,
+.artdeco-button--primary:focus {
+  background-color: #006097;
+  color: #fff
+}
+
+.artdeco-button:active,
+.artdeco-button--primary:active {
+  background-color: #004b7c;
+  color: #fff
+}
+
+.artdeco-button:disabled,
+.artdeco-button--primary:disabled,
+.artdeco-button--disabled.artdeco-button,
+.artdeco-button--disabled.artdeco-button--primary {
+  background-color: rgba(0, 115, 177, 0.35);
+  color: rgba(255, 255, 255, 0.45)
+}
+
+.artdeco-button:disabled .artdeco-button__icon--in-bug,
+.artdeco-button--primary:disabled .artdeco-button__icon--in-bug,
+.artdeco-button--disabled.artdeco-button .artdeco-button__icon--in-bug,
+.artdeco-button--disabled.artdeco-button--primary .artdeco-button__icon--in-bug {
+  opacity: .45
+}
+
+.artdeco-button--premium.artdeco-button,
+.artdeco-button--premium.artdeco-button--primary {
+  background-color: #7a6b3b;
+  color: #fff
+}
+
+.artdeco-button--premium.artdeco-button:visited,
+.artdeco-button--premium.artdeco-button--primary:visited,
+.artdeco-button--premium.artdeco-button:visited:hover,
+.artdeco-button--premium.artdeco-button--primary:visited:hover {
+  background-color: #7a6b3b;
+  color: #fff
+}
+
+.artdeco-button--premium.artdeco-button:hover,
+.artdeco-button--premium.artdeco-button--primary:hover,
+.artdeco-button--premium.artdeco-button:focus,
+.artdeco-button--premium.artdeco-button--primary:focus {
+  background-color: #645831;
+  color: #fff
+}
+
+.artdeco-button--premium.artdeco-button:active,
+.artdeco-button--premium.artdeco-button--primary:active {
+  background-color: #4e4628;
+  color: #fff
+}
+
+.artdeco-button--premium.artdeco-button:disabled,
+.artdeco-button--premium.artdeco-button--primary:disabled,
+.artdeco-button--premium.artdeco-button--disabled.artdeco-button,
+.artdeco-button--premium.artdeco-button--disabled.artdeco-button--primary {
+  background-color: rgba(122, 107, 59, 0.35);
+  color: rgba(255, 255, 255, 0.45)
+}
+
+.artdeco-button--pro.artdeco-button,
+.artdeco-button--pro.artdeco-button--primary {
+  background-color: #004b7c;
+  color: #fff
+}
+
+.artdeco-button--pro.artdeco-button:visited,
+.artdeco-button--pro.artdeco-button--primary:visited,
+.artdeco-button--pro.artdeco-button:visited:hover,
+.artdeco-button--pro.artdeco-button--primary:visited:hover {
+  background-color: #004b7c;
+  color: #fff
+}
+
+.artdeco-button--pro.artdeco-button:hover,
+.artdeco-button--pro.artdeco-button--primary:hover,
+.artdeco-button--pro.artdeco-button:focus,
+.artdeco-button--pro.artdeco-button--primary:focus {
+  background-color: #006097;
+  color: #fff
+}
+
+.artdeco-button--pro.artdeco-button:active,
+.artdeco-button--pro.artdeco-button--primary:active {
+  background-color: #0073b1;
+  color: #fff
+}
+
+.artdeco-button--pro.artdeco-button:disabled,
+.artdeco-button--pro.artdeco-button--primary:disabled,
+.artdeco-button--pro.artdeco-button--disabled.artdeco-button,
+.artdeco-button--pro.artdeco-button--disabled.artdeco-button--primary {
+  background-color: rgba(0, 75, 124, 0.25);
+  color: rgba(255, 255, 255, 0.45)
+}
+
+.artdeco-button--inverse.artdeco-button,
+.artdeco-button--inverse.artdeco-button--primary {
+  background-color: #fff;
+  color: rgba(0, 0, 0, 0.9)
+}
+
+.artdeco-button--inverse.artdeco-button:visited,
+.artdeco-button--inverse.artdeco-button--primary:visited,
+.artdeco-button--inverse.artdeco-button:visited:hover,
+.artdeco-button--inverse.artdeco-button--primary:visited:hover {
+  background-color: #fff;
+  color: rgba(0, 0, 0, 0.9)
+}
+
+.artdeco-button--inverse.artdeco-button:hover,
+.artdeco-button--inverse.artdeco-button--primary:hover,
+.artdeco-button--inverse.artdeco-button:focus,
+.artdeco-button--inverse.artdeco-button--primary:focus {
+  background-color: rgba(255, 255, 255, 0.85);
+  color: rgba(0, 0, 0, 0.9)
+}
+
+.artdeco-button--inverse.artdeco-button:active,
+.artdeco-button--inverse.artdeco-button--primary:active {
+  background-color: #fff;
+  color: rgba(0, 0, 0, 0.9)
+}
+
+.artdeco-button--inverse.artdeco-button:disabled,
+.artdeco-button--inverse.artdeco-button--primary:disabled,
+.artdeco-button--inverse.artdeco-button--disabled.artdeco-button,
+.artdeco-button--inverse.artdeco-button--disabled.artdeco-button--primary {
+  background-color: rgba(255, 255, 255, 0.35);
+  color: rgba(0, 0, 0, 0.25)
+}
+
+.artdeco-button--inverse.artdeco-button:disabled .artdeco-button__icon--in-bug,
+.artdeco-button--inverse.artdeco-button--primary:disabled .artdeco-button__icon--in-bug,
+.artdeco-button--inverse.artdeco-button--disabled.artdeco-button .artdeco-button__icon--in-bug,
+.artdeco-button--inverse.artdeco-button--disabled.artdeco-button--primary .artdeco-button__icon--in-bug {
+  opacity: .35
+}
+
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button,
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--primary {
+  background-color: #dccea4;
+  color: #42391e
+}
+
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button:visited,
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--primary:visited,
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button:visited:hover,
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--primary:visited:hover {
+  background-color: #dccea4;
+  color: #42391e
+}
+
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button:hover,
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--primary:hover,
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button:focus,
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--primary:focus {
+  background-color: #f1e8c5;
+  color: #42391e
+}
+
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button:active,
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--primary:active {
+  background-color: #fdf4dc;
+  color: #42391e
+}
+
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button:disabled,
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--primary:disabled,
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--disabled.artdeco-button,
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--disabled.artdeco-button--primary {
+  background-color: rgba(220, 206, 164, 0.45);
+  color: rgba(66, 57, 30, 0.45)
+}
+
+.artdeco-button--muted.artdeco-button,
+.artdeco-button--muted.artdeco-button--primary {
+  background-color: rgba(0, 0, 0, 0.6);
+  color: #fff
+}
+
+.artdeco-button--muted.artdeco-button:visited,
+.artdeco-button--muted.artdeco-button--primary:visited,
+.artdeco-button--muted.artdeco-button:visited:hover,
+.artdeco-button--muted.artdeco-button--primary:visited:hover {
+  background-color: rgba(0, 0, 0, 0.6);
+  color: #fff
+}
+
+.artdeco-button--muted.artdeco-button:hover,
+.artdeco-button--muted.artdeco-button--primary:hover,
+.artdeco-button--muted.artdeco-button:focus,
+.artdeco-button--muted.artdeco-button--primary:focus {
+  background-color: rgba(0, 0, 0, 0.75);
+  color: #fff
+}
+
+.artdeco-button--muted.artdeco-button:active,
+.artdeco-button--muted.artdeco-button--primary:active {
+  background-color: rgba(0, 0, 0, 0.9);
+  color: #fff
+}
+
+.artdeco-button--muted.artdeco-button:disabled,
+.artdeco-button--muted.artdeco-button--primary:disabled,
+.artdeco-button--muted.artdeco-button--disabled.artdeco-button,
+.artdeco-button--muted.artdeco-button--disabled.artdeco-button--primary {
+  background-color: rgba(0, 0, 0, 0.25);
+  color: rgba(255, 255, 255, 0.45)
+}
+
+.artdeco-button--secondary,
+a.artdeco-button--secondary {
+  background-color: rgba(0, 0, 0, 0);
+  color: #0073b1;
+  -webkit-box-shadow: inset 0 0 0 1px #0073b1;
+  box-shadow: inset 0 0 0 1px #0073b1
+}
+
+.artdeco-button--secondary:visited,
+.artdeco-button--secondary:visited:hover {
+  background-color: rgba(0, 0, 0, 0);
+  color: #0073b1;
+  -webkit-box-shadow: inset 0 0 0 1px #0073b1;
+  box-shadow: inset 0 0 0 1px #0073b1
+}
+
+.artdeco-button--secondary:hover,
+.artdeco-button--secondary:focus {
+  background-color: rgba(152, 216, 244, 0.25);
+  color: #006097;
+  -webkit-box-shadow: inset 0 0 0 2px #006097;
+  box-shadow: inset 0 0 0 2px #006097
+}
+
+.artdeco-button--secondary:active {
+  background-color: rgba(152, 216, 244, 0.45);
+  color: #004b7c;
+  -webkit-box-shadow: inset 0 0 0 2px #004b7c;
+  box-shadow: inset 0 0 0 2px #004b7c
+}
+
+.artdeco-button--secondary:disabled,
+.artdeco-button--disabled.artdeco-button--secondary {
+  background-color: rgba(0, 0, 0, 0);
+  color: rgba(0, 115, 177, 0.35);
+  -webkit-box-shadow: inset 0 0 0 1px rgba(0, 115, 177, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(0, 115, 177, 0.35)
+}
+
+.artdeco-button--premium.artdeco-button--secondary {
+  background-color: rgba(0, 0, 0, 0);
+  color: #7a6b3b;
+  -webkit-box-shadow: inset 0 0 0 1px #7a6b3b;
+  box-shadow: inset 0 0 0 1px #7a6b3b
+}
+
+.artdeco-button--premium.artdeco-button--secondary:visited,
+.artdeco-button--premium.artdeco-button--secondary:visited:hover {
+  background-color: rgba(0, 0, 0, 0);
+  color: #7a6b3b;
+  -webkit-box-shadow: inset 0 0 0 1px #7a6b3b;
+  box-shadow: inset 0 0 0 1px #7a6b3b
+}
+
+.artdeco-button--premium.artdeco-button--secondary:hover,
+.artdeco-button--premium.artdeco-button--secondary:focus {
+  background-color: rgba(220, 206, 164, 0.25);
+  color: #645831;
+  -webkit-box-shadow: inset 0 0 0 2px #645831;
+  box-shadow: inset 0 0 0 2px #645831
+}
+
+.artdeco-button--premium.artdeco-button--secondary:active {
+  background-color: rgba(220, 206, 164, 0.45);
+  color: #4e4628;
+  -webkit-box-shadow: inset 0 0 0 2px #4e4628;
+  box-shadow: inset 0 0 0 2px #4e4628
+}
+
+.artdeco-button--premium.artdeco-button--secondary:disabled,
+.artdeco-button--premium.artdeco-button--disabled.artdeco-button--secondary {
+  background-color: rgba(0, 0, 0, 0);
+  color: rgba(122, 107, 59, 0.35);
+  -webkit-box-shadow: inset 0 0 0 1px rgba(122, 107, 59, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(122, 107, 59, 0.35)
+}
+
+.artdeco-button--pro.artdeco-button--secondary {
+  background-color: rgba(0, 0, 0, 0);
+  color: #004b7c;
+  -webkit-box-shadow: inset 0 0 0 1px #004b7c;
+  box-shadow: inset 0 0 0 1px #004b7c
+}
+
+.artdeco-button--pro.artdeco-button--secondary:visited,
+.artdeco-button--pro.artdeco-button--secondary:visited:hover {
+  background-color: rgba(0, 0, 0, 0);
+  color: #004b7c;
+  -webkit-box-shadow: inset 0 0 0 1px #004b7c;
+  box-shadow: inset 0 0 0 1px #004b7c
+}
+
+.artdeco-button--pro.artdeco-button--secondary:hover,
+.artdeco-button--pro.artdeco-button--secondary:focus {
+  background-color: rgba(152, 216, 244, 0.25);
+  color: #006097;
+  -webkit-box-shadow: inset 0 0 0 2px #006097;
+  box-shadow: inset 0 0 0 2px #006097
+}
+
+.artdeco-button--pro.artdeco-button--secondary:active {
+  background-color: rgba(152, 216, 244, 0.45);
+  color: #0073b1;
+  -webkit-box-shadow: inset 0 0 0 2px #0073b1;
+  box-shadow: inset 0 0 0 2px #0073b1
+}
+
+.artdeco-button--pro.artdeco-button--secondary:disabled,
+.artdeco-button--pro.artdeco-button--disabled.artdeco-button--secondary {
+  background-color: rgba(0, 0, 0, 0);
+  color: rgba(0, 75, 124, 0.35);
+  -webkit-box-shadow: inset 0 0 0 1px rgba(0, 75, 124, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(0, 75, 124, 0.35)
+}
+
+.artdeco-button--inverse.artdeco-button--secondary {
+  background-color: rgba(0, 0, 0, 0);
+  color: #fff;
+  -webkit-box-shadow: inset 0 0 0 1px #fff;
+  box-shadow: inset 0 0 0 1px #fff
+}
+
+.artdeco-button--inverse.artdeco-button--secondary:visited,
+.artdeco-button--inverse.artdeco-button--secondary:visited:hover {
+  background-color: rgba(0, 0, 0, 0);
+  color: #fff;
+  -webkit-box-shadow: inset 0 0 0 1px #fff;
+  box-shadow: inset 0 0 0 1px #fff
+}
+
+.artdeco-button--inverse.artdeco-button--secondary:hover,
+.artdeco-button--inverse.artdeco-button--secondary:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  -webkit-box-shadow: inset 0 0 0 2px #fff;
+  box-shadow: inset 0 0 0 2px #fff
+}
+
+.artdeco-button--inverse.artdeco-button--secondary:active {
+  background-color: rgba(255, 255, 255, 0.25);
+  color: #fff;
+  -webkit-box-shadow: inset 0 0 0 2px #fff;
+  box-shadow: inset 0 0 0 2px #fff
+}
+
+.artdeco-button--inverse.artdeco-button--secondary:disabled,
+.artdeco-button--inverse.artdeco-button--disabled.artdeco-button--secondary {
+  background-color: rgba(0, 0, 0, 0);
+  color: rgba(255, 255, 255, 0.35);
+  -webkit-box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35)
+}
+
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--secondary {
+  background-color: rgba(0, 0, 0, 0);
+  color: #dccea4;
+  -webkit-box-shadow: inset 0 0 0 1px #dccea4;
+  box-shadow: inset 0 0 0 1px #dccea4
+}
+
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--secondary:visited,
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--secondary:visited:hover {
+  background-color: rgba(0, 0, 0, 0);
+  color: #dccea4;
+  -webkit-box-shadow: inset 0 0 0 1px #dccea4;
+  box-shadow: inset 0 0 0 1px #dccea4
+}
+
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--secondary:hover,
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--secondary:focus {
+  background-color: rgba(220, 206, 164, 0.15);
+  color: #f1e8c5;
+  -webkit-box-shadow: inset 0 0 0 2px #f1e8c5;
+  box-shadow: inset 0 0 0 2px #f1e8c5
+}
+
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--secondary:active {
+  background-color: rgba(220, 206, 164, 0.25);
+  color: #fdf4dc;
+  -webkit-box-shadow: inset 0 0 0 2px #fdf4dc;
+  box-shadow: inset 0 0 0 2px #fdf4dc
+}
+
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--secondary:disabled,
+.artdeco-button--inverse.artdeco-button--premium.artdeco-button--disabled.artdeco-button--secondary {
+  background-color: rgba(0, 0, 0, 0);
+  color: rgba(220, 206, 164, 0.45);
+  -webkit-box-shadow: inset 0 0 0 1px rgba(220, 206, 164, 0.45);
+  box-shadow: inset 0 0 0 1px rgba(220, 206, 164, 0.45)
+}
+
+.artdeco-button--muted.artdeco-button--secondary {
+  background-color: rgba(0, 0, 0, 0);
+  color: rgba(0, 0, 0, 0.6);
+  -webkit-box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.6)
+}
+
+.artdeco-button--muted.artdeco-button--secondary:visited,
+.artdeco-button--muted.artdeco-button--secondary:visited:hover {
+  background-color: rgba(0, 0, 0, 0);
+  color: rgba(0, 0, 0, 0.6);
+  -webkit-box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.6)
+}
+
+.artdeco-button--muted.artdeco-button--secondary:hover,
+.artdeco-button--muted.artdeco-button--secondary:focus {
+  background-color: rgba(207, 207, 207, 0.25);
+  color: rgba(0, 0, 0, 0.75);
+  -webkit-box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.75);
+  box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.75)
+}
+
+.artdeco-button--muted.artdeco-button--secondary:active {
+  background-color: rgba(207, 207, 207, 0.45);
+  color: rgba(0, 0, 0, 0.9);
+  -webkit-box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.9);
+  box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.9)
+}
+
+.artdeco-button--muted.artdeco-button--secondary:disabled,
+.artdeco-button--muted.artdeco-button--disabled.artdeco-button--secondary {
+  background-color: rgba(0, 0, 0, 0);
+  color: rgba(0, 0, 0, 0.25);
+  -webkit-box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25)
+}
+
+.artdeco-button--muted.artdeco-button--secondary:disabled .artdeco-button__icon--in-bug,
+.artdeco-button--muted.artdeco-button--disabled.artdeco-button--secondary .artdeco-button__icon--in-bug {
+  opacity: .35
+}
+
+.artdeco-button--tertiary,
+a.artdeco-button--tertiary {
+  background-color: rgba(0, 0, 0, 0);
+  color: #0073b1
+}
+
+.artdeco-button--tertiary:visited,
+.artdeco-button--tertiary:visited:hover {
+  background-color: rgba(0, 0, 0, 0);
+  color: #0073b1
+}
+
+.artdeco-button--tertiary:hover,
+.artdeco-button--tertiary:focus {
+  background-color: rgba(152, 216, 244, 0.25);
+  color: #006097
+}
+
+.artdeco-button--tertiary:active {
+  background-color: rgba(152, 216, 244, 0.45);
+  color: #004b7c
+}
+
+.artdeco-button--tertiary:disabled,
+.artdeco-button--disabled.artdeco-button--tertiary {
+  background-color: rgba(0, 0, 0, 0);
+  color: rgba(0, 115, 177, 0.35)
+}
+
+.artdeco-button--pro.artdeco-button--tertiary {
+  background-color: rgba(0, 0, 0, 0);
+  color: #004b7c
+}
+
+.artdeco-button--pro.artdeco-button--tertiary:visited,
+.artdeco-button--pro.artdeco-button--tertiary:visited:hover {
+  background-color: rgba(0, 0, 0, 0);
+  color: #004b7c
+}
+
+.artdeco-button--pro.artdeco-button--tertiary:hover,
+.artdeco-button--pro.artdeco-button--tertiary:focus {
+  background-color: rgba(152, 216, 244, 0.25);
+  color: #006097
+}
+
+.artdeco-button--pro.artdeco-button--tertiary:active {
+  background-color: rgba(152, 216, 244, 0.45);
+  color: #0073b1
+}
+
+.artdeco-button--pro.artdeco-button--tertiary:disabled,
+.artdeco-button--pro.artdeco-button--disabled.artdeco-button--tertiary {
+  background-color: rgba(0, 0, 0, 0);
+  color: rgba(0, 75, 124, 0.35)
+}
+
+.artdeco-button--inverse.artdeco-button--tertiary {
+  background-color: rgba(0, 0, 0, 0);
+  color: #fff
+}
+
+.artdeco-button--inverse.artdeco-button--tertiary:visited,
+.artdeco-button--inverse.artdeco-button--tertiary:visited:hover {
+  background-color: rgba(0, 0, 0, 0);
+  color: #fff
+}
+
+.artdeco-button--inverse.artdeco-button--tertiary:hover,
+.artdeco-button--inverse.artdeco-button--tertiary:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: #fff
+}
+
+.artdeco-button--inverse.artdeco-button--tertiary:active {
+  background-color: rgba(255, 255, 255, 0.25);
+  color: #fff
+}
+
+.artdeco-button--inverse.artdeco-button--tertiary:disabled,
+.artdeco-button--inverse.artdeco-button--disabled.artdeco-button--tertiary {
+  background-color: rgba(0, 0, 0, 0);
+  color: rgba(255, 255, 255, 0.35)
+}
+
+.artdeco-button--muted.artdeco-button--tertiary {
+  background-color: rgba(0, 0, 0, 0);
+  color: rgba(0, 0, 0, 0.6)
+}
+
+.artdeco-button--muted.artdeco-button--tertiary:visited,
+.artdeco-button--muted.artdeco-button--tertiary:visited:hover {
+  background-color: rgba(0, 0, 0, 0);
+  color: rgba(0, 0, 0, 0.6)
+}
+
+.artdeco-button--muted.artdeco-button--tertiary:hover,
+.artdeco-button--muted.artdeco-button--tertiary:focus {
+  background-color: rgba(207, 207, 207, 0.25);
+  color: rgba(0, 0, 0, 0.75)
+}
+
+.artdeco-button--muted.artdeco-button--tertiary:active {
+  background-color: rgba(207, 207, 207, 0.45);
+  color: rgba(0, 0, 0, 0.9)
+}
+
+.artdeco-button--muted.artdeco-button--tertiary:disabled,
+.artdeco-button--muted.artdeco-button--disabled.artdeco-button--tertiary {
+  background-color: rgba(0, 0, 0, 0);
+  color: rgba(0, 0, 0, 0.25)
+}
+
+.artdeco-button,
+.artdeco-button--2 {
+  font-size: 1.6rem;
+  min-height: 3.2rem;
+  padding: 0.6rem 1.2rem;
+  line-height: 2rem
+}
+
+.artdeco-button--circle.artdeco-button,
+.artdeco-button--circle.artdeco-button--2 {
+  height: 4rem;
+  width: 4rem;
+  min-width: auto
+}
+
+.artdeco-button--1 {
+  font-size: 1.4rem;
+  min-height: 2.4rem;
+  padding: 0.2rem 0.8rem;
+  line-height: 2rem
+}
+
+.artdeco-button--circle.artdeco-button--1 {
+  height: 3.2rem;
+  width: 3.2rem;
+  min-width: auto
+}
+
+.artdeco-button--3 {
+  font-size: 1.6rem;
+  min-height: 4rem;
+  padding: 1rem 1.6rem;
+  line-height: 2rem
+}
+
+.artdeco-button--circle.artdeco-button--3 {
+  height: 4.8rem;
+  width: 4.8rem;
+  min-width: auto
+}
+
+.artdeco-button--4 {
+  font-size: 2rem;
+  min-height: 4.8rem;
+  padding: 1rem 2rem;
+  line-height: 2.8rem
+}
+
+.artdeco-button--circle.artdeco-button--4 {
+  height: 5.6rem;
+  width: 5.6rem;
+  min-width: auto
+}
+
+.artdeco-button {
+  -webkit-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  -webkit-transition-duration: 167ms;
+  transition-duration: 167ms;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: none;
+  border-radius: 2px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  min-width: 6.4rem;
+  max-width: 480px;
+  overflow: hidden;
+  text-align: center;
+  -webkit-transition-property: background-color, color, -webkit-box-shadow;
+  transition-property: background-color, color, -webkit-box-shadow;
+  transition-property: background-color, box-shadow, color;
+  transition-property: background-color, box-shadow, color, -webkit-box-shadow;
+  vertical-align: middle
+}
+
+.artdeco-button:disabled {
+  cursor: not-allowed
+}
+
+.artdeco-button:disabled * {
+  pointer-events: none
+}
+
+.artdeco-button.artdeco-button--disabled {
+  cursor: not-allowed
+}
+
+.artdeco-button.artdeco-button--disabled * {
+  pointer-events: none
+}
+
+.artdeco-button--tertiary {
+  padding-left: 8px;
+  padding-right: 8px
+}
+
+.artdeco-button--circle {
+  border-radius: 49.5%;
+  padding: 0
+}
+
+.artdeco-button--circle .artdeco-button__text {
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px
+}
+
+.artdeco-button--fluid {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  border-radius: 0;
+  max-width: 100%;
+  width: 100%
+}
+
+.artdeco-button--full {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1
+}
+
+.artdeco-button--full+.artdeco-button--full {
+  margin-left: 8px
+}
+
+.artdeco-button--icon-right {
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: reverse;
+  -ms-flex-direction: row-reverse;
+  flex-direction: row-reverse
+}
+
+.artdeco-button__icon {
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin: 0 4px 0 -2px
+}
+
+.artdeco-button--4 .artdeco-button__icon {
+  margin-left: -4px
+}
+
+.artdeco-button--tertiary .artdeco-button__icon {
+  margin-left: -2px
+}
+
+.artdeco-button--icon-right .artdeco-button__icon {
+  margin: 0 -2px 0 4px
+}
+
+.artdeco-button__icon .artdeco-button--4 .artdeco-button__icon.artdeco-button--icon-right {
+  margin-left: 6px
+}
+
+.artdeco-button__icon .artdeco-button--4.artdeco-button--tertiary .artdeco-button__icon.artdeco-button--icon-right {
+  margin-left: 4px
+}
+
+.artdeco-button__icon.artdeco-button__icon--in-bug {
+  margin: 0 4px 0 0
+}
+
+.artdeco-button__icon .artdeco-button--4 .artdeco-button__icon.artdeco-button__icon--in-bug {
+  margin-right: 6px
+}
+
+.artdeco-button--circle .artdeco-button__icon {
+  margin: 0
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .artdeco-button--primary,
+  .artdeco-button--secondary,
+  .artdeco-button--tertiary {
+    background-color: transparent
+  }
+  .artdeco-button--primary:not(a),
+  .artdeco-button--secondary:not(a),
+  .artdeco-button--tertiary:not(a) {
+    color: ButtonText !important
+  }
+  .artdeco-button--primary:hover,
+  .artdeco-button--primary:focus,
+  .artdeco-button--primary:active,
+  .artdeco-button--secondary:hover,
+  .artdeco-button--secondary:focus,
+  .artdeco-button--secondary:active,
+  .artdeco-button--tertiary:hover,
+  .artdeco-button--tertiary:focus,
+  .artdeco-button--tertiary:active {
+    border: 1px solid ButtonText !important;
+    -webkit-box-shadow: inset 0px 0px 0px 1px ButtonText !important;
+    box-shadow: inset 0px 0px 0px 1px ButtonText !important
+  }
+  .artdeco-button--primary:disabled,
+  .artdeco-button--primary:disabled:hover,
+  .artdeco-button--primary:disabled:focus,
+  .artdeco-button--primary:disabled:active,
+  .artdeco-button--primary.artdeco-button--disabled,
+  .artdeco-button--primary.artdeco-button--disabled:hover,
+  .artdeco-button--primary.artdeco-button--disabled:focus,
+  .artdeco-button--primary.artdeco-button--disabled:active,
+  .artdeco-button--secondary:disabled,
+  .artdeco-button--secondary:disabled:hover,
+  .artdeco-button--secondary:disabled:focus,
+  .artdeco-button--secondary:disabled:active,
+  .artdeco-button--secondary.artdeco-button--disabled,
+  .artdeco-button--secondary.artdeco-button--disabled:hover,
+  .artdeco-button--secondary.artdeco-button--disabled:focus,
+  .artdeco-button--secondary.artdeco-button--disabled:active,
+  .artdeco-button--tertiary:disabled,
+  .artdeco-button--tertiary:disabled:hover,
+  .artdeco-button--tertiary:disabled:focus,
+  .artdeco-button--tertiary:disabled:active,
+  .artdeco-button--tertiary.artdeco-button--disabled,
+  .artdeco-button--tertiary.artdeco-button--disabled:hover,
+  .artdeco-button--tertiary.artdeco-button--disabled:focus,
+  .artdeco-button--tertiary.artdeco-button--disabled:active {
+    color: GrayText !important;
+    border: 1px solid GrayText !important;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+    outline: none
+  }
+  .artdeco-button--tertiary {
+    border: 1px solid transparent
+  }
+  .artdeco-button--primary,
+  .artdeco-button--secondary {
+    border: 1px solid ButtonText !important
+  }
+}
+
+a.artdeco-button.artdeco-button--primary {
+  outline: 4px solid rgba(0, 145, 202, 0);
+  outline-offset: 8px;
+  -webkit-transition-property: outline, outline-offset;
+  transition-property: outline, outline-offset;
+  -webkit-transition-timing-function: ease-out;
+  transition-timing-function: ease-out;
+  -webkit-transition-duration: 0ms;
+  transition-duration: 0ms
+}
+
+a.artdeco-button.artdeco-button--primary:focus {
+  outline: 4px solid #0091ca;
+  outline-offset: 2px;
+  -webkit-transition-duration: 83ms;
+  transition-duration: 83ms
+}
+
+a.artdeco-button.artdeco-button--primary.artdeco-button--inverse {
+  outline: 4px solid rgba(202, 237, 255, 0)
+}
+
+a.artdeco-button.artdeco-button--primary.artdeco-button--inverse:focus {
+  outline: 4px solid #caedff
+}
+
+#artdeco-global-alert-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: 0;
+  overflow: hidden
+}
+
+.artdeco-global-alert {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-color: #5c6f7c;
+  width: 100%;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  overflow: hidden;
+  position: absolute;
+  -webkit-transform: translateY(0);
+  transform: translateY(0);
+  padding: 0 12px
+}
+
+@media screen and (max-width: 769px) {
+  .artdeco-global-alert {
+    padding: 0 16px
+  }
+}
+
+.artdeco-global-alert--yield {
+  background-color: #b74700
+}
+
+.artdeco-global-alert--yield .artdeco-global-alert-action__wrapper .artdeco-button {
+  color: #b74700
+}
+
+.artdeco-global-alert--yield .artdeco-global-alert-action__wrapper .artdeco-button:active {
+  color: #b74700
+}
+
+.artdeco-global-alert--yield .artdeco-global-alert__responsive-container::after {
+  background-image: -webkit-gradient(linear, left top, left bottom, from(transparent), to(#b74700));
+  background-image: linear-gradient(transparent, #b74700)
+}
+
+.artdeco-global-alert--yield .artdeco-global-alert__responsive-container::before {
+  background-image: -webkit-gradient(linear, left top, left bottom, from(#b74700), to(transparent));
+  background-image: linear-gradient(#b74700, transparent)
+}
+
+.artdeco-global-alert--YIELD {
+  background-color: #b74700
+}
+
+.artdeco-global-alert--YIELD .artdeco-global-alert-action__wrapper .artdeco-button {
+  color: #b74700
+}
+
+.artdeco-global-alert--YIELD .artdeco-global-alert-action__wrapper .artdeco-button:active {
+  color: #b74700
+}
+
+.artdeco-global-alert--YIELD .artdeco-global-alert__responsive-container::after {
+  background-image: -webkit-gradient(linear, left top, left bottom, from(transparent), to(#b74700));
+  background-image: linear-gradient(transparent, #b74700)
+}
+
+.artdeco-global-alert--YIELD .artdeco-global-alert__responsive-container::before {
+  background-image: -webkit-gradient(linear, left top, left bottom, from(#b74700), to(transparent));
+  background-image: linear-gradient(#b74700, transparent)
+}
+
+.artdeco-global-alert--error {
+  background-color: #d11124
+}
+
+.artdeco-global-alert--error .artdeco-global-alert-action__wrapper .artdeco-button {
+  color: #d11124
+}
+
+.artdeco-global-alert--error .artdeco-global-alert-action__wrapper .artdeco-button:active {
+  color: #d11124
+}
+
+.artdeco-global-alert--error .artdeco-global-alert__responsive-container::after {
+  background-image: -webkit-gradient(linear, left top, left bottom, from(transparent), to(#d11124));
+  background-image: linear-gradient(transparent, #d11124)
+}
+
+.artdeco-global-alert--error .artdeco-global-alert__responsive-container::before {
+  background-image: -webkit-gradient(linear, left top, left bottom, from(#d11124), to(transparent));
+  background-image: linear-gradient(#d11124, transparent)
+}
+
+.artdeco-global-alert--ERROR {
+  background-color: #d11124
+}
+
+.artdeco-global-alert--ERROR .artdeco-global-alert-action__wrapper .artdeco-button {
+  color: #d11124
+}
+
+.artdeco-global-alert--ERROR .artdeco-global-alert-action__wrapper .artdeco-button:active {
+  color: #d11124
+}
+
+.artdeco-global-alert--ERROR .artdeco-global-alert__responsive-container::after {
+  background-image: -webkit-gradient(linear, left top, left bottom, from(transparent), to(#d11124));
+  background-image: linear-gradient(transparent, #d11124)
+}
+
+.artdeco-global-alert--ERROR .artdeco-global-alert__responsive-container::before {
+  background-image: -webkit-gradient(linear, left top, left bottom, from(#d11124), to(transparent));
+  background-image: linear-gradient(#d11124, transparent)
+}
+
+.artdeco-global-alert__body {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+  width: 100%;
+  max-width: 1161px;
+  position: relative;
+  padding: 16px 0
+}
+
+.artdeco-global-alert__body p {
+  color: #fff
+}
+
+.artdeco-global-alert__body li-icon.artdeco-global-alert__icon {
+  height: 24px;
+  width: 24px
+}
+
+.artdeco-global-alert__body li-icon.artdeco-global-alert__icon--dismissed {
+  height: 16px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border: 8px solid transparent;
+  -webkit-box-sizing: content-box;
+  box-sizing: content-box
+}
+
+button.artdeco-global-alert__dismiss {
+  width: 32px;
+  height: 32px;
+  right: 0;
+  background: none;
+  border: none;
+  position: relative;
+  cursor: pointer
+}
+
+.artdeco-global-alert__content {
+  font-size: 1.6rem;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #fff;
+  width: 100%;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  word-wrap: break-word;
+  overflow-wrap: anywhere
+}
+
+.artdeco-global-alert__content a {
+  color: #fff;
+  text-decoration: underline
+}
+
+.artdeco-global-alert__content a:visited {
+  color: #fff
+}
+
+.artdeco-global-alert__content a:visited:active {
+  color: #fff
+}
+
+.artdeco-global-alert__content p:not(:first-child) {
+  margin: 16px 0 0
+}
+
+@media screen and (max-width: 769px) {
+  .artdeco-global-alert__content {
+    font-size: 1.4rem;
+    line-height: 1.42857;
+    font-weight: 400;
+    color: #fff;
+    width: auto;
+    max-height: 96px;
+    overflow: auto
+  }
+}
+
+.artdeco-global-alert__responsive-container {
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  margin: 0 0 0 16px
+}
+
+@media screen and (max-width: 769px) {
+  .artdeco-global-alert__responsive-container {
+    position: relative
+  }
+  .artdeco-global-alert__responsive-container::after {
+    width: 100%;
+    height: 20px;
+    position: absolute;
+    background-image: -webkit-gradient(linear, left top, left bottom, from(transparent), to(#5c6f7c));
+    background-image: linear-gradient(transparent, #5c6f7c);
+    top: 76px
+  }
+  .artdeco-global-alert__responsive-container::before {
+    width: 100%;
+    height: 20px;
+    position: absolute;
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#5c6f7c), to(transparent));
+    background-image: linear-gradient(#5c6f7c, transparent);
+    top: 0
+  }
+}
+
+.artdeco-global-alert__responsive-container--scrollable-effect::before,
+.artdeco-global-alert__responsive-container--scrollable-effect::after {
+  content: ' '
+}
+
+.artdeco-global-alert__responsive-container--scrollable-effect-only-top::before {
+  content: ' '
+}
+
+.artdeco-global-alert__responsive-container--scrollable-effect-only-top::after {
+  display: none
+}
+
+.artdeco-global-alert__responsive-container--scrollable-effect-only-bottom::after {
+  content: ' '
+}
+
+.artdeco-global-alert__responsive-container--scrollable-effect-only-bottom::before {
+  display: none
+}
+
+.artdeco-global-alert-action__wrapper {
+  padding: 16px 0 0
+}
+
+.artdeco-global-alert-action__wrapper .artdeco-button {
+  color: #5c6f7c
+}
+
+.artdeco-global-alert-action__wrapper .artdeco-button:active {
+  color: #5c6f7c
+}
+
+.artdeco-global-alert-action__wrapper button:not(:first-child) {
+  margin: 0 0 0 8px
+}
+
+@media screen and (max-width: 560px) {
+  .artdeco-global-alert-action__wrapper {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: reverse;
+    -ms-flex-direction: column-reverse;
+    flex-direction: column-reverse;
+    padding: 0;
+    margin-left: -40px
+  }
+  .artdeco-global-alert-action__wrapper button:nth-child(n) {
+    margin: 16px 0 0
+  }
+}
+
+#artdeco-global-alert-container.transition-in,
+#artdeco-global-alert-container .artdeco-global-alert.transition-in,
+body.transition-in {
+  -webkit-transition-duration: 0.334s;
+  transition-duration: 0.334s;
+  -webkit-transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1)
+}
+
+#artdeco-global-alert-container.transition-out,
+#artdeco-global-alert-container .artdeco-global-alert.transition-out,
+body.transition-out {
+  -webkit-transition-duration: 0.167s;
+  transition-duration: 0.167s;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+  transition-timing-function: cubic-bezier(0.4, 0, 1, 1)
+}
+
+.global-alert-banner {
+  z-index: 900
+}
+
+* {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box
+}
+
+ul,
+ol {
+  list-style: none
+}
+
+button {
+  background-color: transparent;
+  padding: 0
+}
+
+li {
+  text-align: left
+}
+
+strong {
+  font-weight: 700
+}
+
+a {
+  text-decoration: none
+}
+
+a:hover {
+  text-decoration: underline
+}
+
+button,
+input {
+  border: 1px solid transparent
+}
+
+a {
+  text-decoration: none;
+  font-weight: 600;
+  background-color: transparent;
+  border: 0;
+  color: #0073b1
+}
+
+a:visited {
+  color: #0073b1
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+  color: #006097
+}
+
+a:active {
+  color: #004b7c
+}
+
+a:visited {
+  color: #665ed0
+}
+
+a:visited:hover {
+  color: #544bc2
+}
+
+a:visited:active {
+  color: #4034b0
+}
+
+a,
+a:focus,
+a:hover {
+  color: #0a66c2
+}
+
+a:active {
+  color: #004182
+}
+
+a:visited,
+a:visited:hover {
+  color: #8344cc
+}
+
+a:visited:active {
+  color: #592099
+}
+
+.artdeco-entity-image {
+  display: inline-block;
+  -ms-flex-negative: 0;
+  flex-shrink: 0
+}
+
+.artdeco-entity-image--circle-1 {
+  width: 32px;
+  height: 32px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 3px solid rgba(0, 0, 0, 0);
+  border-radius: 49.9%
+}
+
+.artdeco-entity-image--square-1 {
+  width: 32px;
+  height: 32px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 4px solid rgba(0, 0, 0, 0);
+  border-radius: 6px
+}
+
+.artdeco-entity-image--circle-2 {
+  width: 40px;
+  height: 40px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 3px solid rgba(0, 0, 0, 0);
+  border-radius: 49.9%
+}
+
+.artdeco-entity-image--square-2 {
+  width: 40px;
+  height: 40px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 4px solid rgba(0, 0, 0, 0);
+  border-radius: 6px
+}
+
+.artdeco-entity-image--circle-3 {
+  width: 48px;
+  height: 48px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 2px solid rgba(0, 0, 0, 0);
+  border-radius: 49.9%
+}
+
+.artdeco-entity-image--square-3 {
+  width: 48px;
+  height: 48px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 4px solid rgba(0, 0, 0, 0);
+  border-radius: 6px
+}
+
+.artdeco-entity-image--circle-4 {
+  width: 56px;
+  height: 56px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 2px solid rgba(0, 0, 0, 0);
+  border-radius: 49.9%
+}
+
+.artdeco-entity-image--square-4 {
+  width: 56px;
+  height: 56px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 4px solid rgba(0, 0, 0, 0);
+  border-radius: 6px
+}
+
+.artdeco-entity-image--circle-5 {
+  width: 72px;
+  height: 72px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 1px solid rgba(0, 0, 0, 0);
+  border-radius: 49.9%
+}
+
+.artdeco-entity-image--square-5 {
+  width: 72px;
+  height: 72px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 4px solid rgba(0, 0, 0, 0);
+  border-radius: 6px
+}
+
+.artdeco-entity-image--circle-6 {
+  width: 88px;
+  height: 88px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 1px solid rgba(0, 0, 0, 0);
+  border-radius: 49.9%
+}
+
+.artdeco-entity-image--square-6 {
+  width: 88px;
+  height: 88px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 4px solid rgba(0, 0, 0, 0);
+  border-radius: 6px
+}
+
+.artdeco-entity-image--circle-7 {
+  width: 104px;
+  height: 104px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 0px solid rgba(0, 0, 0, 0);
+  border-radius: 49.9%
+}
+
+.artdeco-entity-image--square-7 {
+  width: 104px;
+  height: 104px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 4px solid rgba(0, 0, 0, 0);
+  border-radius: 6px
+}
+
+.artdeco-entity-image--circle-8 {
+  width: 128px;
+  height: 128px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 0px solid rgba(0, 0, 0, 0);
+  border-radius: 49.9%
+}
+
+.artdeco-entity-image--square-8 {
+  width: 128px;
+  height: 128px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  background-clip: content-box;
+  border: 4px solid rgba(0, 0, 0, 0);
+  border-radius: 6px
+}
+
+.artdeco-entity-image--ghost {
+  background-color: #b3b6b9
+}
+
+.profile-badge {
+  background-color: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  -webkit-box-shadow: 0px -1px 1px rgba(0, 0, 0, 0.08), 1px 0px 1px rgba(0, 0, 0, 0.08), -1px 0px 1px rgba(0, 0, 0, 0.08), 0px 1px 1px rgba(0, 0, 0, 0.08);
+  box-shadow: 0px -1px 1px rgba(0, 0, 0, 0.08), 1px 0px 1px rgba(0, 0, 0, 0.08), -1px 0px 1px rgba(0, 0, 0, 0.08), 0px 1px 1px rgba(0, 0, 0, 0.08);
+  padding: 0
+}
+
+.profile-badge--width-250 {
+  width: 250px
+}
+
+.profile-badge--width-280 {
+  width: 280px
+}
+
+.profile-badge--width-300 {
+  width: 300px
+}
+
+.profile-badge--width-330 {
+  width: 330px
+}
+
+.profile-badge--light {
+  background-color: #fff;
+  color: #000
+}
+
+.profile-badge--dark {
+  background-color: #000;
+  color: #fff
+}
+
+.profile-badge__header {
+  padding: 12px 16px
+}
+
+.profile-badge__header--light {
+  background-color: #e9e5df
+}
+
+.profile-badge__header--dark {
+  background-color: #38434f
+}
+
+.profile-badge__header-logo-icon {
+  width: 84px;
+  height: 21px;
+  display: inline-block
+}
+
+.profile-badge__header-logo-icon--light {
+  color: #0a66c2
+}
+
+.profile-badge__header-logo-icon--dark {
+  color: #fff
+}
+
+.profile-badge__content {
+  padding: 0 16px
+}
+
+.profile-badge__content-profile-image {
+  margin: 12px 0 8px
+}
+
+.profile-badge__content-profile-name {
+  padding: 0 0 4px;
+  color: inherit
+}
+
+.profile-badge__content-profile-name-link {
+  font-size: 1.6rem;
+  line-height: 1.5;
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.9);
+  color: inherit
+}
+
+.profile-badge__content-profile-name-link--dark:focus,
+.profile-badge__content-profile-name-link--dark:hover,
+.profile-badge__content-profile-name-link--dark:active {
+  color: #fff
+}
+
+.profile-badge__content-profile-name-link--dark:visited,
+.profile-badge__content-profile-name-link--dark:visited:active,
+.profile-badge__content-profile-name-link--dark:visited:focus,
+.profile-badge__content-profile-name-link--dark:visited:hover {
+  color: #fff
+}
+
+.profile-badge__content-profile-name-link--light:focus,
+.profile-badge__content-profile-name-link--light:hover,
+.profile-badge__content-profile-name-link--light:active {
+  color: #000
+}
+
+.profile-badge__content-profile-name-link--light:visited,
+.profile-badge__content-profile-name-link--light:visited:active,
+.profile-badge__content-profile-name-link--light:visited:focus,
+.profile-badge__content-profile-name-link--light:visited:hover {
+  color: #000
+}
+
+.profile-badge__content-profile-headline {
+  padding: 0 0 4px;
+  font-size: 1.4rem;
+  line-height: 1.42857;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.9);
+  color: inherit
+}
+
+.profile-badge__content-profile-company-school-info {
+  padding: 0 0 4px;
+  font-size: 1.2rem;
+  line-height: 1.33333;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.6);
+  color: inherit
+}
+
+.profile-badge__content-profile-company-school-info-link {
+  font-size: 1.2rem;
+  line-height: 1.33333;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.6);
+  color: inherit
+}
+
+.profile-badge__content-profile-company-school-info-link--dark:focus,
+.profile-badge__content-profile-company-school-info-link--dark:hover,
+.profile-badge__content-profile-company-school-info-link--dark:active {
+  color: #fff
+}
+
+.profile-badge__content-profile-company-school-info-link--dark:visited,
+.profile-badge__content-profile-company-school-info-link--dark:visited:active,
+.profile-badge__content-profile-company-school-info-link--dark:visited:focus,
+.profile-badge__content-profile-company-school-info-link--dark:visited:hover {
+  color: #fff
+}
+
+.profile-badge__content-profile-company-school-info-link--light:focus,
+.profile-badge__content-profile-company-school-info-link--light:hover,
+.profile-badge__content-profile-company-school-info-link--light:active {
+  color: #000
+}
+
+.profile-badge__content-profile-company-school-info-link--light:visited,
+.profile-badge__content-profile-company-school-info-link--light:visited:active,
+.profile-badge__content-profile-company-school-info-link--light:visited:focus,
+.profile-badge__content-profile-company-school-info-link--light:visited:hover {
+  color: #000
+}
+
+.profile-badge__cta-btn {
+  margin: 4px 16px 12px;
+  color: inherit
+}
+
+.profile-badge__cta-btn--light {
+  background-color: rgba(0, 0, 0, 0);
+  border: 0;
+  border-radius: 2px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  color: #0073b1;
+  cursor: pointer;
+  display: inline-block;
+  font-size: 1.6rem;
+  font-weight: 600;
+  font-family: inherit;
+  height: 32px;
+  line-height: 32px;
+  overflow: hidden;
+  outline-width: 2px;
+  padding: 0 16px;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  -webkit-transition-duration: 167ms;
+  transition-duration: 167ms;
+  -webkit-transition-property: background-color, color, -webkit-box-shadow;
+  transition-property: background-color, color, -webkit-box-shadow;
+  transition-property: background-color, box-shadow, color;
+  transition-property: background-color, box-shadow, color, -webkit-box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  vertical-align: middle;
+  z-index: 0;
+  -webkit-box-shadow: inset 0 0 0 1px #0073b1, inset 0 0 0 2px rgba(0, 0, 0, 0), inset 0 0 0 1px rgba(0, 0, 0, 0);
+  box-shadow: inset 0 0 0 1px #0073b1, inset 0 0 0 2px rgba(0, 0, 0, 0), inset 0 0 0 1px rgba(0, 0, 0, 0);
+  border-radius: 24px;
+  -webkit-box-shadow: inset 0 0 0 1px #0a66c2;
+  box-shadow: inset 0 0 0 1px #0a66c2;
+  color: #0a66c2
+}
+
+@media only screen and (-ms-high-contrast: active) {
+  .profile-badge__cta-btn--light {
+    border: 1px solid currentColor;
+    line-height: 30px
+  }
+}
+
+html.ie .profile-badge__cta-btn--light:focus,
+html.edge .profile-badge__cta-btn--light:focus {
+  outline: 1px dashed #7f7f7f
+}
+
+.profile-badge__cta-btn--light li-icon {
+  top: 2px;
+  -webkit-box-sizing: content-box;
+  box-sizing: content-box;
+  height: 16px;
+  left: 0;
+  margin: -12px 0 0 -6px;
+  padding: 0 6px 0 0;
+  position: relative;
+  width: 16px
+}
+
+.profile-badge__cta-btn--light li-icon>svg {
+  -webkit-transition: -webkit-transform 167ms;
+  transition: -webkit-transform 167ms;
+  transition: transform 167ms;
+  transition: transform 167ms, -webkit-transform 167ms;
+  -webkit-transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  display: inline-block;
+  vertical-align: top
+}
+
+.edge .profile-badge__cta-btn--light,
+.ie .profile-badge__cta-btn--light {
+  border-radius: 0
+}
+
+.profile-badge__cta-btn--light:not(:disabled)[data-is-animating-click=true],
+.profile-badge__cta-btn--light:hover:not(:disabled)[data-is-animating-click=true] {
+  -webkit-box-shadow: inset 0 0 0 1px #0073b1, inset 0 0 0 2px rgba(0, 0, 0, 0), inset 0 0 0 1px #004b7c;
+  box-shadow: inset 0 0 0 1px #0073b1, inset 0 0 0 2px rgba(0, 0, 0, 0), inset 0 0 0 1px #004b7c
+}
+
+.profile-badge__cta-btn--light:hover:not(:disabled):not(.disabled),
+.profile-badge__cta-btn--light.hover-not-disabled {
+  background-color: rgba(152, 216, 244, 0.25);
+  color: #006097;
+  -webkit-box-shadow: inset 0 0 0 1px #0073b1, inset 0 0 0 2px #006097, inset 0 0 0 1px rgba(0, 0, 0, 0);
+  box-shadow: inset 0 0 0 1px #0073b1, inset 0 0 0 2px #006097, inset 0 0 0 1px rgba(0, 0, 0, 0)
+}
+
+.profile-badge__cta-btn--light:focus,
+.profile-badge__cta-btn--light.focus {
+  background-color: rgba(152, 216, 244, 0.25);
+  color: #006097;
+  -webkit-box-shadow: inset 0 0 0 1px #0073b1, inset 0 0 0 2px #006097, inset 0 0 0 1px rgba(0, 0, 0, 0);
+  box-shadow: inset 0 0 0 1px #0073b1, inset 0 0 0 2px #006097, inset 0 0 0 1px rgba(0, 0, 0, 0)
+}
+
+.profile-badge__cta-btn--light:active:not(:disabled):not(.disabled),
+.profile-badge__cta-btn--light.active-not-disabled {
+  background-color: rgba(152, 216, 244, 0.45);
+  color: #004b7c
+}
+
+.profile-badge__cta-btn--light:disabled,
+.profile-badge__cta-btn--light.disabled {
+  color: rgba(0, 115, 177, 0.35);
+  -webkit-box-shadow: inset 0 0 0 1px rgba(0, 115, 177, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(0, 115, 177, 0.35);
+  cursor: not-allowed
+}
+
+.profile-badge__cta-btn--light:focus,
+.profile-badge__cta-btn--light.focus,
+.profile-badge__cta-btn--light:hover:not(:disabled):not(.disabled),
+.profile-badge__cta-btn--light.hover-not-disabled {
+  -webkit-box-shadow: inset 0 0 0 2px #0a66c2;
+  box-shadow: inset 0 0 0 2px #0a66c2
+}
+
+.profile-badge__cta-btn--light:active,
+.profile-badge__cta-btn--light.active,
+.profile-badge__cta-btn--light:active:not(:disabled):not(.disabled),
+.profile-badge__cta-btn--light.active-not-disabled {
+  -webkit-box-shadow: inset 0 0 0 1px #004182;
+  box-shadow: inset 0 0 0 1px #004182
+}
+
+.profile-badge__cta-btn--light:focus,
+.profile-badge__cta-btn--light.focus,
+.profile-badge__cta-btn--light:hover:not(:disabled):not(.disabled),
+.profile-badge__cta-btn--light.hover-not-disabled {
+  background-color: rgba(112, 181, 249, 0.15);
+  color: #0a66c2
+}
+
+.profile-badge__cta-btn--light:active,
+.profile-badge__cta-btn--light.active,
+.profile-badge__cta-btn--light:active:not(:disabled):not(.disabled),
+.profile-badge__cta-btn--light.active-not-disabled {
+  background-color: rgba(112, 181, 249, 0.3);
+  color: #004182
+}
+
+.profile-badge__cta-btn--light:visited,
+.profile-badge__cta-btn--light:visited:active,
+.profile-badge__cta-btn--light:visited:focus,
+.profile-badge__cta-btn--light:visited:hover {
+  color: #0a66c2
+}
+
+.profile-badge__cta-btn--light:hover {
+  color: #0a66c2;
+  text-decoration: none !important
+}
+
+.profile-badge__cta-btn--dark {
+  background-color: rgba(0, 0, 0, 0);
+  border: 0;
+  border-radius: 2px;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  color: #fff;
+  cursor: pointer;
+  display: inline-block;
+  font-size: 1.6rem;
+  font-weight: 600;
+  font-family: inherit;
+  height: 32px;
+  line-height: 32px;
+  overflow: hidden;
+  outline-width: 2px;
+  padding: 0 16px;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  -webkit-transition-duration: 167ms;
+  transition-duration: 167ms;
+  -webkit-transition-property: background-color, color, -webkit-box-shadow;
+  transition-property: background-color, color, -webkit-box-shadow;
+  transition-property: background-color, box-shadow, color;
+  transition-property: background-color, box-shadow, color, -webkit-box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  vertical-align: middle;
+  z-index: 0;
+  -webkit-box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7), inset 0 0 0 2px rgba(0, 0, 0, 0), inset 0 0 0 1px rgba(0, 0, 0, 0);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7), inset 0 0 0 2px rgba(0, 0, 0, 0), inset 0 0 0 1px rgba(0, 0, 0, 0);
+  border-radius: 24px;
+  -webkit-box-shadow: inset 0 0 0 1px #fff;
+  box-shadow: inset 0 0 0 1px #fff;
+  box-shadow: inset 0 0 0 1px #fff
+}
+
+@media only screen and (-ms-high-contrast: active) {
+  .profile-badge__cta-btn--dark {
+    border: 1px solid currentColor;
+    line-height: 30px
+  }
+}
+
+html.ie .profile-badge__cta-btn--dark:focus,
+html.edge .profile-badge__cta-btn--dark:focus {
+  outline: 1px dashed #7f7f7f
+}
+
+.profile-badge__cta-btn--dark li-icon {
+  top: 2px;
+  -webkit-box-sizing: content-box;
+  box-sizing: content-box;
+  height: 16px;
+  left: 0;
+  margin: -12px 0 0 -6px;
+  padding: 0 6px 0 0;
+  position: relative;
+  width: 16px
+}
+
+.profile-badge__cta-btn--dark li-icon>svg {
+  -webkit-transition: -webkit-transform 167ms;
+  transition: -webkit-transform 167ms;
+  transition: transform 167ms;
+  transition: transform 167ms, -webkit-transform 167ms;
+  -webkit-transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  display: inline-block;
+  vertical-align: top
+}
+
+.edge .profile-badge__cta-btn--dark,
+.ie .profile-badge__cta-btn--dark {
+  border-radius: 0
+}
+
+.profile-badge__cta-btn--dark:not(:disabled)[data-is-animating-click=true],
+.profile-badge__cta-btn--dark:hover:not(:disabled)[data-is-animating-click=true] {
+  -webkit-box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7), inset 0 0 0 2px rgba(0, 0, 0, 0), inset 0 0 0 1px #fff;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7), inset 0 0 0 2px rgba(0, 0, 0, 0), inset 0 0 0 1px #fff
+}
+
+.profile-badge__cta-btn--dark:hover:not(:disabled):not(.disabled),
+.profile-badge__cta-btn--dark.hover-not-disabled {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  -webkit-box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7), inset 0 0 0 2px #fff, inset 0 0 0 1px rgba(0, 0, 0, 0);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7), inset 0 0 0 2px #fff, inset 0 0 0 1px rgba(0, 0, 0, 0)
+}
+
+.profile-badge__cta-btn--dark:focus,
+.profile-badge__cta-btn--dark.focus {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  -webkit-box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7), inset 0 0 0 2px #fff, inset 0 0 0 1px rgba(0, 0, 0, 0);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7), inset 0 0 0 2px #fff, inset 0 0 0 1px rgba(0, 0, 0, 0)
+}
+
+.profile-badge__cta-btn--dark:active:not(:disabled):not(.disabled),
+.profile-badge__cta-btn--dark.active-not-disabled {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: #fff
+}
+
+.profile-badge__cta-btn--dark:disabled,
+.profile-badge__cta-btn--dark.disabled {
+  color: rgba(255, 255, 255, 0.35);
+  -webkit-box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
+  cursor: not-allowed
+}
+
+.profile-badge__cta-btn--dark:visited,
+.profile-badge__cta-btn--dark:visited:active,
+.profile-badge__cta-btn--dark:visited:focus,
+.profile-badge__cta-btn--dark:visited:hover {
+  color: #fff
+}
+
+.profile-badge__cta-btn--dark:hover {
+  color: #fff;
+  text-decoration: none !important
+}
+
+#LIbadge h4 {
+  font-size: 80%
+}
+
+#LIbadge a {
+  font-size: 80%
+}
+
+.profile-badge {
+  width: 100% !important;
+  border-radius: 0px !important;
+}
+
+.profile-badge__cta-btn {
+display: none !important;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,6 @@
 
 		<title>Global NL - Member Portal</title>
 
-		<script type='text/javascript' src='https://platform.linkedin.com/badges/js/profile.js' async defer></script>
 		<!-- Font-Awesome: -->
 		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous">
 
@@ -235,10 +234,6 @@
 				</form>
 					<br/>
 
-			</div>
-
-			<div id="LIbadge" class="select2-container border">
-				<!-- LI badge html goes here -->
 			</div>
 
 		<!-- tab-content -->

--- a/public/index.js
+++ b/public/index.js
@@ -34,7 +34,31 @@ function renderWithUser(user) {
   $("#members-list").empty();
   $("#mainPage").show();  
   $('#loginModal').modal("hide"); // login modal for mobile app users when they tap send message without signing in
-  initLoad();
+  if (getUrlParameter('profile')) {
+    var profileID = getUrlParameter('profile');
+    var memberDocRef = fbi.doc(profileID);
+    memberDocRef
+      .get()
+      .then(doc => {
+        if (!doc.exists) {
+          console.log("User does not exist in database");
+          window.location.replace('index.html');
+        } else {          
+          fbi
+          .where(firebase.firestore.FieldPath.documentId(), '==', profileID)
+          .limit(1)
+          .get()
+          .then(function(querySnapshot) {
+            loadMembers(querySnapshot, true);
+          });
+        }
+      })
+      .catch(err => {
+        console.log("Error getting document", err);
+      });
+  } else {    
+    initLoad();
+  }
   showAdminToggle();
 }
 
@@ -47,8 +71,38 @@ function renderWithoutUser() {
       $(".clear_button").click(); // load members when mobile app users visit index.html even without signing in
     });
   } else { // not mobile app
-    $("#members-list").empty();
-    $("#mainPage").hide();
+    if (getUrlParameter('profile')) {
+      $("#members-list").empty();
+      $("#loginPage").hide();
+      $("#mainPage").show();
+      var profileID = getUrlParameter('profile');
+      var memberDocRef = fbi.doc(profileID);
+      memberDocRef
+        .get()
+        .then(doc => {
+          if (!doc.exists) {
+            console.log("User does not exist in database");
+            window.location.replace('index.html');
+          } else {          
+            fbi
+            .where("privacy", "==", "public")
+            .where(firebase.firestore.FieldPath.documentId(), '==', profileID)
+            .limit(1)
+            .get()
+            .then(function(querySnapshot) {
+              loadMembers(querySnapshot, true);
+            });
+          }
+        })
+        .catch(err => {
+          console.log("Error getting document", err);          
+          $("#mainPage").hide();
+          $("#loginPage").show();
+        });
+    } else {    
+      $("#members-list").empty();
+      $("#mainPage").hide();
+    }
   }
 }
 
@@ -131,8 +185,7 @@ function createSendAMessageForm(id, toDisplayName, fromEmailAddress) {
  * Register event callbacks & implement element callbacks
  ******************************************************/
 // Init auth on load web page event
-$(document).ready(function() {          
-  $("#LIbadge").hide();
+$(document).ready(function() {
   $("#preloader").hide();
   if (navigator.userAgent.indexOf('gonative') > -1) { // for mobile app
     $('.navbar-brand').attr('href', '#'); // so that tapping GlobalNL logo does not redirect anywhere
@@ -469,99 +522,29 @@ function initLoad() {
                 console.log("Profile Pic does not exist in the storage. Default photo will be used user account photoURL");
               });
             }
-
         } else {
-            var profileLink = doc.data().linkedin_profile;
-            var vanityName = profileLink.substring(profileLink.indexOf('/in/')+4).replace('/','');
-            var photoURL, companyName, companyLogo;
-
-            $("#LIbadge").html(`<div class='LI-profile-badge'  data-version='v1' data-size='large' data-locale='en_US' data-type='horizontal' data-theme='light' data-vanity='${vanityName}'><a class='LI-simple-link' style='display: none' href='${profileLink}?trk=profile-badge'>LinkedIn badge</a></div>`);
-            LIRenderAll();                        
-            let uploadPhoto;
-            let uploadCompanyLogo;
-            setTimeout(function(){
-              if (!$(".LI-name").length > 0) {
-                  console.log("Failed to load badge. Database and Storage not updated.");
-              } else {
-                  //LinkedIn badge info
-                  if ($(".LI-profile-pic").length>0) photoURL = $(".LI-profile-pic").attr("src");
-                  
-                  if ($(".LI-field-icon").length>0) companyLogo = $(".LI-field-icon").attr("src");
-
-                  // checking if users photoURL in the database is valid
-                  if (photoURL && doc.data().photoURL !== photoURL && !/ghost/gi.test(photoURL)) { // global, case-insensitive regex test
-                    firebase.firestore().collection("members").doc(doc.id).update({
-                      photoURL: photoURL
-                    });
-                    uploadPhoto = uploadPhotoOnFirebaseStorage(photoURL, doc.id);
-                  } else {
-                    console.log("No need to update photo");
-                  }
-                  // checking if users company_logo in the database is valid
-                  if (companyLogo && doc.data().company_logo !== companyLogo && !/ghost/gi.test(companyLogo)) { // global, case-insensitive regex test
-                    firebase.firestore().collection("members").doc(doc.id).update({
-                      company_logo: companyLogo
-                    });
-                    uploadCompanyLogo = uploadCompanyLogoOnFirebaseStorage(companyLogo, doc.id);
-                    if ($(".LI-field").length>0 && $(".LI-field > img")) { // grabbing the first img tag
-                      companyName = $(".LI-field > img").attr("alt"); // getting the first img tag's alt attribute, which contains the name of the company
-                      if (companyName && doc.data().company !== companyName) {
-                        firebase.firestore().collection("members").doc(doc.id).update({
-                          company: companyName,
-                          company_lower: companyName.toLowerCase()
-                        });
-                      }
-                    }    
-                  } else {
-                    console.log("No need to update company logo.");
-                  }
-
-                  return Promise.all([uploadPhoto, uploadCompanyLogo]).then(() => {
-                    console.log("Completed both storage uploads if it was required");                
-                    $("#LIbadge").remove();
-                    // Create a reference to the file we want to download
-                    var profilePicRef = firebase.storage().ref("images/members/" + doc.id + "/profile_picture/" + doc.id + "_profile-picture");
-                    // Get the download URL
-                    profilePicRef.getDownloadURL()
-                    .then((url) => {
-                      firebase.auth().currentUser.updateProfile({
-                        photoURL: url,
-                      })
-                      .then(function() {
-                        console.log("Successfully updated user account photoURL");
-                        $("#user_photo").attr('src', url); // update the navbar user photo with the updated user account photoURL from firebase storage
-                        $(`#${doc.id}_photoURL`).attr('src', url); // update member display photo icon from firebase storage url
-                        if (doc.data().company) {                     
-                          var companyLogoRef = firebase.storage().ref("images/members/" + doc.id + "/company_logo/" + doc.id + "_company-logo");
-                          // Get the download URL
-                          companyLogoRef.getDownloadURL()
-                          .then((url) => {
-                            // Insert url into the companyLogo <img> tag to "download"
-                            $(`#${doc.id}_companyLogo`).attr('src', url); // update member display company logo from firebase storage url
-                          })
-                          .catch((error) => {
-                            // A full list of error codes is available at
-                            // https://firebase.google.com/docs/storage/web/handle-errors
-                            console.log("Company logo does not exist in the storage. Default logo will be used");
-                          });
-                        }
-                      })
-                      .catch(function(error) {
-                        console.log(error);
-                        console.log("Error updating user account photoURL for ", doc.id);
-                      });
-                    })
-                    .catch((error) => {
-                      // A full list of error codes is available at
-                      // https://firebase.google.com/docs/storage/web/handle-errors
-                      console.log("Profile Pic does not exist in the storage. Default photo will be used user account photoURL");
-                    });
-                  })
-                  .catch(err => {
-                    console.log(err);
-                  });
-              }
-            }, 700); // if there are issues with valid profile links not loading the badge, try increasing this timeout            
+          var profilePicRef = firebase.storage().ref("images/members/" + doc.id + "/profile_picture/" + doc.id + "_profile-picture");
+          // Get the download URL
+          profilePicRef.getDownloadURL()
+          .then((url) => {
+            firebase.auth().currentUser.updateProfile({
+              photoURL: url,
+            })
+            .then(function() {
+              console.log("Successfully updated user account photoURL");
+              $("#user_photo").attr('src', url); // update the navbar user photo with the updated user account photoURL from firebase storage
+              $(`#${doc.id}_photoURL`).attr('src', url); // update member display photo icon from firebase storage url
+            })
+            .catch(function(error) {
+              console.log(error);
+              console.log("Error updating user account photoURL for ", doc.id);
+            });
+          })
+          .catch((error) => {
+            // A full list of error codes is available at
+            // https://firebase.google.com/docs/storage/web/handle-errors
+            console.log("Profile Pic does not exist in the storage. Default photo will be used user account photoURL");
+          });
         }
 
         formDynamic["current_address"] = doc.data().current_address;
@@ -625,6 +608,23 @@ function profile() {
   console.log("Nav profile.html");
   window.location.href = "profile.html";
 }
+
+// To get the profile parameter 
+function getUrlParameter(sParam) {
+  var sPageURL = window.location.search.substring(1),
+      sURLVariables = sPageURL.split('&'),
+      sParameterName,
+      i;
+
+  for (i = 0; i < sURLVariables.length; i++) {
+      sParameterName = sURLVariables[i].split('=');
+
+      if (sParameterName[0] === sParam) {
+          return typeof sParameterName[1] === undefined ? true : decodeURIComponent(sParameterName[1]);
+      }
+  }
+  return false;
+};
 
 // Promise function, will resolve if the profile picture is uploaded properly on firebase storage
 function uploadPhotoOnFirebaseStorage(url, uid) {
@@ -690,9 +690,11 @@ function uploadCompanyLogoOnFirebaseStorage(url, uid) {
   });
 }
 
-/* load members */
-function loadMembers(querySnapshot) {
-  if (querySnapshot.docs.length > 0) {
+/** load members 
+* @param singleProfileLoad (boolean) true in case of loading single profile from URL parameter ?profile=PROFILE_ID
+*/
+function loadMembers(querySnapshot, singleProfileLoad = false) {
+  if (querySnapshot.docs.length > 0 || singleProfileLoad) {
     last_read_doc = querySnapshot.docs[querySnapshot.docs.length - 1];
     querySnapshot.forEach(function(doc) {
       // doc.data() is never undefined for query doc snapshots
@@ -842,8 +844,8 @@ function loadMembers(querySnapshot) {
         showAdminButton();
         memberDomString = `<div class="col-auto p-1 card-col">
 <div class="card card-gnl">
-	<div>
-	<div class="card-header card-header-gnl">
+  <div>
+  <div class="card-header card-header-gnl">
   <span class="fas fa-gnl-head">
   <img id="${memberFields.public_uid}_photoURL" src="${photoURL}" class="gnl-user-photo"></span>
   <div class="card-profile-title">
@@ -852,9 +854,9 @@ function loadMembers(querySnapshot) {
   ${memberFields.headline}</div>
   </div>
   </div>
-	<div class="munLogoAdder" style="visibility: ${vis};"><img src="assets/MUN_Logo_Pantone_Border_Small.jpg" alt="MUN LOGO"></div>
-	</div>
-	<div class="card-body card-body-gnl">
+  <div class="munLogoAdder" style="visibility: ${vis};"><img src="assets/MUN_Logo_Pantone_Border_Small.jpg" alt="MUN LOGO"></div>
+  </div>
+  <div class="card-body card-body-gnl">
     <h5 class="card-title"><span class="fas fa-globalnl"><img id="${memberFields.public_uid}_companyLogo" style="width: 100%" src="${companyLogo}"></span>${
       memberFields.company
     }</h5>
@@ -894,8 +896,8 @@ function loadMembers(querySnapshot) {
         showAdminButton();
         memberDomString = `<div class="col-auto p-1 card-col">
 <div class="card card-gnl">
-	<div>
-	<div class="card-header card-header-gnl">
+  <div>
+  <div class="card-header card-header-gnl">
   <span class="fas fa-gnl-head">
   <img id="${memberFields.public_uid}_photoURL" src="${photoURL}" class="gnl-user-photo"></span>
   <div class="card-profile-title">
@@ -904,9 +906,9 @@ function loadMembers(querySnapshot) {
   ${memberFields.headline}</div>
   </div>
   </div>
-	<div class="munLogoAdder" style="visibility: ${vis};"><img src="assets/MUN_Logo_Pantone_Border_Small.jpg" alt="MUN LOGO"></div>
-	</div>
-	<div class="card-body card-body-gnl">
+  <div class="munLogoAdder" style="visibility: ${vis};"><img src="assets/MUN_Logo_Pantone_Border_Small.jpg" alt="MUN LOGO"></div>
+  </div>
+  <div class="card-body card-body-gnl">
     <h5 class="card-title"><span class="fas fa-globalnl"><img id="${memberFields.public_uid}_companyLogo" style="width: 100%" src="${companyLogo}"></span>${
       memberFields.company
     }</h5>
@@ -1075,8 +1077,8 @@ function loadMembers(querySnapshot) {
         showAdminButton();
         memberDomString = `<div class="col-auto p-1 card-col">
 <div class="card card-gnl">
-	<div>
-	<div class="card-header card-header-gnl">
+  <div>
+  <div class="card-header card-header-gnl">
   <span class="fas fa-gnl-head">
   <img id="${memberFields.public_uid}_photoURL" src="${photoURL}" class="gnl-user-photo"></span>
   <div class="card-profile-title">
@@ -1085,9 +1087,9 @@ function loadMembers(querySnapshot) {
   ${memberFields.headline}</div>
   </div>
   </div>
-	<div class="munLogoAdder" style="visibility: ${vis};"><img src="assets/MUN_Logo_Pantone_Border_Small.jpg" alt="MUN LOGO"></div>
-	</div>
-	<div class="card-body card-body-gnl">
+  <div class="munLogoAdder" style="visibility: ${vis};"><img src="assets/MUN_Logo_Pantone_Border_Small.jpg" alt="MUN LOGO"></div>
+  </div>
+  <div class="card-body card-body-gnl">
     <h5 class="card-title"><span class="fas fa-globalnl fa-industry"></span>${
       cardIndustry
     }</h5>
@@ -1123,7 +1125,7 @@ function loadMembers(querySnapshot) {
 }
 
 /* Searching
-	Need to clean this up...
+  Need to clean this up...
 */
 
 function memberSearch() {

--- a/public/profile.js
+++ b/public/profile.js
@@ -27,11 +27,17 @@ $(document).ready(function() {
     if (profileUsername) { // true if user comes back properly from their linkedin page
     // start loading the linkedin badge
       $("#linkedin").val('https://www.linkedin.com/in/' + profileUsername);
-      $("#LIbadge").html(`<div class='LI-profile-badge'  data-version='v1' data-size='large' data-locale='en_US' data-type='horizontal' data-theme='light' data-vanity='${profileUsername}'><a class='LI-simple-link' style="display: none" href='https://www.linkedin.com/in/${profileUsername}?trk=profile-badge'>LinkedIn badge</a></div>`);
+      $("#LIbadge").html(`<div class="badge-base LI-profile-badge" data-locale="en_US" data-size="large" data-theme="light" data-type="HORIZONTAL" data-vanity="${profileUsername}" data-version="v1"></div>`);
       LIRenderAll();
       $("#badgeLoading").hide();
       setTimeout(function(){
-        if (!$(".LI-name").length > 0) {
+        var cssElements=document.getElementsByTagName("link")
+        for (var i=cssElements.length; i>=0; i--) {
+          if (cssElements[i] && cssElements[i].getAttribute("href")!=null && cssElements[i].getAttribute("href").indexOf("licdn")!=-1) {
+            cssElements[i].parentNode.removeChild(cssElements[i]);
+          }
+        }
+        if (!$(".profile-badge__content").length > 0) {
           $("#LIbadge").html(`<div class="badge-error-message">Error loading LinkedIn profile!</div><div class="badge-error-message">Please check your profile link.</div>`)
         }
       }, 1000); // if there are issues with valid profile links not loading the badge, try increasing this timeout
@@ -302,20 +308,20 @@ $("#submitButton").click(function(event) {
   // checkif hometown address was given
   if (locationArray.hasOwnProperty("hometown_address")) {
     member["hometown_address"] = locationArray["hometown_address"];
-    //	memberGeo.id = uid;
-    //	memberGeo.hometownLat = locationArray["hometown_address"]["lat"];
-    //	memberGeo.hometownLng = locationArray["hometown_address"]["lng"];
+    //  memberGeo.id = uid;
+    //  memberGeo.hometownLat = locationArray["hometown_address"]["lat"];
+    //  memberGeo.hometownLng = locationArray["hometown_address"]["lng"];
   }
   // checkif current address was given
   if (locationArray.hasOwnProperty("current_address")) {
     member["current_address"] = locationArray["current_address"];
-    //	memberGeo.id = uid;
-    //	memberGeo.currentLat = locationArray["current_address"]["lat"];
-    //	memberGeo.currentLng = locationArray["current_address"]["lng"];
+    //  memberGeo.id = uid;
+    //  memberGeo.currentLat = locationArray["current_address"]["lat"];
+    //  memberGeo.currentLng = locationArray["current_address"]["lng"];
   }
 
   //if(memberGeo.id){
-  //	$.post( "GeoUser", memberGeo , function(data, status, jqXHR) {console.log('status: ' + status + ', data: ' + data);})
+  //  $.post( "GeoUser", memberGeo , function(data, status, jqXHR) {console.log('status: ' + status + ', data: ' + data);})
   //}
 
   member.bio = $("#bio").val();
@@ -342,15 +348,15 @@ $("#submitButton").click(function(event) {
   }
 
   //LinkedIn badge info
-  if ($(".LI-profile-pic").length>0) member.photoURL = $(".LI-profile-pic").attr("src");
-  if ($(".LI-title").length>0) member.headline = $(".LI-title").text();
+  if ($(".artdeco-entity-image.artdeco-entity-image--circle-4.profile-badge__content-profile-image").length>0) member.photoURL = $(".artdeco-entity-image.artdeco-entity-image--circle-4.profile-badge__content-profile-image").attr("src");
+  if ($(".profile-badge__content-profile-headline").length>0) member.headline = $(".profile-badge__content-profile-headline").text();
   member.company = '';
   member.company_lower = '';
-  if ($(".LI-field").length>0 && $(".LI-field > img")) { // grabbing the first img tag
-    member.company = $(".LI-field > img").attr("alt"); // getting the first img tag's alt attribute, which contains the name of the company
+  if ($(".profile-badge__content-profile-company-school-info").length>0 && $(".profile-badge__content-profile-company-school-info-field > a:first-of-type")) { // getting the first a tag
+    member.company = $(".profile-badge__content-profile-company-school-info > a:first-of-type").text(); // getting the first a tag's text, which contains the name of the company
     member.company_lower = member.company.toLowerCase();
   }
-  if ($(".LI-field-icon").length>0) member.company_logo = $(".LI-field-icon").attr("src");
+  // if ($(".LI-field-icon").length>0) member.company_logo = $(".LI-field-icon").attr("src"); // old badge script which used to show company logo was stored like this
 
   var private_data = {};
 
@@ -525,16 +531,22 @@ function initApp() {
 
         if (userData["bio"] != null) $("#bio").text(userData["bio"]);
 
-    		if (userData["linkedin_profile"] != null) {
+        if (userData["linkedin_profile"] != null) {
           $("#linkedin").val(userData["linkedin_profile"]);
-          $("#LIbadge").html(`<div class='LI-profile-badge'  data-version='v1' data-size='large' data-locale='en_US' data-type='horizontal' data-theme='light' data-vanity='${userData["linkedin_profile"].substring(userData["linkedin_profile"].indexOf('/in/')+4).replace('/','')}'><a class='LI-simple-link' style="display: none" href='${userData["linkedin_profile"]}?trk=profile-badge'>LinkedIn badge</a></div>`);
+          $("#LIbadge").html(`<div class="badge-base LI-profile-badge" data-locale="en_US" data-size="large" data-theme="light" data-type="HORIZONTAL" data-vanity="${userData["linkedin_profile"].substring(userData["linkedin_profile"].indexOf('/in/')+4).replace('/','')}" data-version="v1"></div>`);
           LIRenderAll();
           $("#badgeLoading").hide();
           setTimeout(function(){
-            if (!$(".LI-name").length > 0) {
+            var cssElements=document.getElementsByTagName("link")
+            for (var i=cssElements.length; i>=0; i--) {
+              if (cssElements[i] && cssElements[i].getAttribute("href")!=null && cssElements[i].getAttribute("href").indexOf("licdn")!=-1) {
+                cssElements[i].parentNode.removeChild(cssElements[i]);
+              }
+            }        
+            if (!$(".profile-badge__content").length > 0) {
               $("#LIbadge").html(`<div class="badge-error-message">Error loading LinkedIn profile!</div><div class="badge-error-message">Please check your profile link.</div>`)
             }
-          }, 600); // if there are issues with valid profile links not loading the badge, try increasing this timeout
+          }, 1000); // if there are issues with valid profile links not loading the badge, try increasing this timeout
         }
 
         // Privacy
@@ -548,56 +560,56 @@ function initApp() {
 
         //Use LinkedIn location if current location not set
         /*
-		if(userData["current_address"] != null && !userData["current_address"]["form_address"] && userData["current_address"]["LinkedInLocation"] && userData["current_address"]["LinkedInLocation"] != "Newfoundland And Labrador, Canada"){
-			
-			var linkedinLocation = userData["current_address"]["LinkedInLocation"].replace(' Area', '');
+    if(userData["current_address"] != null && !userData["current_address"]["form_address"] && userData["current_address"]["LinkedInLocation"] && userData["current_address"]["LinkedInLocation"] != "Newfoundland And Labrador, Canada"){
+      
+      var linkedinLocation = userData["current_address"]["LinkedInLocation"].replace(' Area', '');
 
-			var geocoder = new google.maps.Geocoder();
+      var geocoder = new google.maps.Geocoder();
 
-			// Look for these keys in the place object returned by google API
-			// if found, their values are filled and written to our new member object
-			var locationData = {
-				street_number               : true,
-				route                       : true,
-				locality                    : true,
-				administrative_area_level_1 : true,
-				country                     : true,
-				postal_code                 : true
-			};
+      // Look for these keys in the place object returned by google API
+      // if found, their values are filled and written to our new member object
+      var locationData = {
+        street_number               : true,
+        route                       : true,
+        locality                    : true,
+        administrative_area_level_1 : true,
+        country                     : true,
+        postal_code                 : true
+      };
 
-			geocoder.geocode( { "address": linkedinLocation }, function(results, status) {
-				if (status == google.maps.GeocoderStatus.OK && results.length > 0) {
-					// iterate over object and look for the keys in locationData
-					$("#autocomplete_current").val( results[0].formatted_address );
-					locationArray["current_address"] = {
-						locality: null,
-						administrative_area_level_1 : null,  
-						country: null,  
-						locality_short: null,
-						administrative_area_level_1_short : null,  
-						country_short: null, 
-						postal_code: null,
-						lat: null,  
-						lng: null
-					};
-					for (var i = 0; i < results[0].address_components.length; i++) {
-						var addressType = results[0].address_components[i].types[0];
-						if (locationData.hasOwnProperty(addressType)) {
-							locationArray["current_address"][addressType] = results[0].address_components[i]["long_name"];
-							locationArray["current_address"][addressType + "_short"] = results[0].address_components[i]["short_name"];
-						}
-					}
-					// Store geometry into new member object as well
-					locationArray["current_address"]["lat"] = results[0].geometry.location.lat();
-					locationArray["current_address"]["lng"] = results[0].geometry.location.lng();
-					locationArray["current_address"]["form_address"] = $("#autocomplete_current").val();
-				}
-			});
+      geocoder.geocode( { "address": linkedinLocation }, function(results, status) {
+        if (status == google.maps.GeocoderStatus.OK && results.length > 0) {
+          // iterate over object and look for the keys in locationData
+          $("#autocomplete_current").val( results[0].formatted_address );
+          locationArray["current_address"] = {
+            locality: null,
+            administrative_area_level_1 : null,  
+            country: null,  
+            locality_short: null,
+            administrative_area_level_1_short : null,  
+            country_short: null, 
+            postal_code: null,
+            lat: null,  
+            lng: null
+          };
+          for (var i = 0; i < results[0].address_components.length; i++) {
+            var addressType = results[0].address_components[i].types[0];
+            if (locationData.hasOwnProperty(addressType)) {
+              locationArray["current_address"][addressType] = results[0].address_components[i]["long_name"];
+              locationArray["current_address"][addressType + "_short"] = results[0].address_components[i]["short_name"];
+            }
+          }
+          // Store geometry into new member object as well
+          locationArray["current_address"]["lat"] = results[0].geometry.location.lat();
+          locationArray["current_address"]["lng"] = results[0].geometry.location.lng();
+          locationArray["current_address"]["form_address"] = $("#autocomplete_current").val();
+        }
+      });
 
 
 
-		}
-		*/
+    }
+    */
       }
     })
     .catch(err => {
@@ -704,14 +716,20 @@ $('#linkedin').change(() => {
   $("#badgeLoading").show();
   let profileLink = $("#linkedin").val();
   let vanityName = profileLink.substring(profileLink.indexOf('/in/')+4).replace('/','');
-  $("#LIbadge").html(`<div class='LI-profile-badge'  data-version='v1' data-size='large' data-locale='en_US' data-type='horizontal' data-theme='light' data-vanity='${vanityName}'><a class='LI-simple-link' style='display: none' href='${profileLink}?trk=profile-badge'>LinkedIn badge</a></div>`);
+  $("#LIbadge").html(`<div class="badge-base LI-profile-badge" data-locale="en_US" data-size="large" data-theme="light" data-type="HORIZONTAL" data-vanity="${vanityName}" data-version="v1"></div>`);
   LIRenderAll();
   $("#badgeLoading").hide();
-  setTimeout(function(){
-    if (!$(".LI-name").length > 0) {
+  setTimeout(function() {
+    var cssElements=document.getElementsByTagName("link")
+    for (var i=cssElements.length; i>=0; i--) {
+      if (cssElements[i] && cssElements[i].getAttribute("href")!=null && cssElements[i].getAttribute("href").indexOf("licdn")!=-1) {
+        cssElements[i].parentNode.removeChild(cssElements[i]);
+      }
+    }        
+    if (!$(".profile-badge__content").length > 0) {
       $("#LIbadge").html(`<div class="badge-error-message">Error loading LinkedIn profile!</div><div class="badge-error-message">Please check your profile link.</div>`)
     }
-  }, 600); // if there are issues with valid profile links not loading the badge, try increasing this timeout
+  }, 1000); // if there are issues with valid profile links not loading the badge, try increasing this timeout
 });
 
 /*****************************************************


### PR DESCRIPTION
LinkedIn Badge fix and Load member profile from URL
* Load Member Profile from URL
- Member profiles can be loaded now by providing 'profile' url query param. E.g. https://members.globalnl.com/?profile=PROFILE_ID (index.js, Line 37-61, 74-105, 693-697)

* LinkedIn Badge Fix
- Removed LinkedIn Badge script from index.html (Line 23, 240-243)
- Removed LinkedIn Badge usage from index.js (Line 135, 474-564)
- Replaced old LinkedIn Badge usage with newer version in profile.js
- Replaced old LinkedIn Badge css selectors with the newer version's css selectors to get profile info and store in database. (profile.js, Line 351-359)
- Added css in globalnl.css to fix LinkedIn Badge styling (globalnl.css, Line 490-2394)

* function\index.js changes
- Added safe check for email address and profile URL returned by LinkedIn in consideration for the edge case where a user does not have a profile picture set on LinkedIn (Line 274-283, 288, 289)